### PR TITLE
Track Dexcom session history changes and display in settings

### DIFF
--- a/Luka/Views/RootViewModel.swift
+++ b/Luka/Views/RootViewModel.swift
@@ -30,7 +30,13 @@ import Defaults
     }
 
     var sessionID: UUID? = Keychain.shared.sessionID {
-        didSet { keychain.sessionID = sessionID }
+        didSet {
+            keychain.sessionID = sessionID
+
+            if let sessionID, sessionID != oldValue {
+                DexcomSessionHistory.record(sessionID: sessionID)
+            }
+        }
     }
 
     var isSignedIn: Bool {
@@ -62,5 +68,6 @@ import Defaults
         password = nil
         accountID = nil
         sessionID = nil
+        DexcomSessionHistory.clear()
     }
 }

--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @Default(.targetRangeUpperBound) private var upperTargetRange
     @Default(.graphUpperBound) private var upperGraphRange
     @Default(.unit) private var unit
+    @Default(.sessionHistory) private var sessionHistory
 
     var body: some View {
         FooterScrollView {
@@ -62,6 +63,12 @@ struct SettingsView: View {
                         currentValue: $lowerTargetRange,
                         range: 55...110
                     )
+                }
+
+                FormHeader(title: "Dexcom Sessions")
+
+                FormSection {
+                    SessionHistoryTable(entries: sessionHistory)
                 }
 
                 Text("Version \(Bundle.main.fullVersion)")
@@ -122,6 +129,51 @@ private struct GraphSliderView: View {
             )
         }
         .padding(.standardPadding / 2)
+    }
+}
+
+private struct SessionHistoryTable: View {
+    var entries: [DexcomSessionHistoryEntry]
+
+    private var rows: [DexcomSessionHistoryEntry] {
+        entries.sorted { $0.recordedAt > $1.recordedAt }
+    }
+
+    var body: some View {
+        if rows.isEmpty {
+            FormRow(title: "No session history yet")
+        } else {
+            Grid(alignment: .leading, horizontalSpacing: .horizontalSpacing, verticalSpacing: .spacing4) {
+                GridRow {
+                    Text("Session ID")
+                    Text("Date")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                Divider()
+                    .gridCellColumns(2)
+
+                ForEach(rows) { entry in
+                    GridRow {
+                        Text(entry.sessionID.uuidString)
+                            .font(.footnote)
+                            .fontDesign(.monospaced)
+                            .textSelection(.enabled)
+
+                        Text(entry.recordedAt.formatted(date: .abbreviated, time: .shortened))
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if entry.id != rows.last?.id {
+                        Divider()
+                            .gridCellColumns(2)
+                    }
+                }
+            }
+            .padding(.standardPadding / 2)
+        }
     }
 }
 

--- a/Shared/Utilities/Constants.swift
+++ b/Shared/Utilities/Constants.swift
@@ -19,6 +19,7 @@ extension String {
     static let targetRangeUpperBound = "targetRangeUpperBound"
     static let graphUpperBound = "graphUpperBound"
     static let cachedReadings = "chachedReadings"
+    static let sessionHistory = "sessionHistory"
 }
 
 extension CGFloat {

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -21,7 +21,42 @@ extension Defaults.Keys {
     static let unit = Key<GlucoseFormatter.Unit>("unit", default: .mgdl, suite: .shared, iCloud: true)
 
     static let selectedRange = Key("selectedRange", default: GraphRange.eightHours)
+    static let sessionHistory = Key<[DexcomSessionHistoryEntry]>(
+        .sessionHistory,
+        default: [],
+        suite: .shared,
+        iCloud: true
+    )
 }
 
 extension AccountLocation: Defaults.Serializable {}
 extension GlucoseFormatter.Unit: Defaults.Serializable {}
+
+struct DexcomSessionHistoryEntry: Defaults.Serializable, Identifiable, Codable, Equatable {
+    var sessionID: UUID
+    var recordedAt: Date
+
+    var id: UUID { sessionID }
+
+    init(sessionID: UUID, recordedAt: Date = .now) {
+        self.sessionID = sessionID
+        self.recordedAt = recordedAt
+    }
+}
+
+enum DexcomSessionHistory {
+    static func record(sessionID: UUID, at date: Date = .now) {
+        var history = Defaults[.sessionHistory]
+
+        if history.last?.sessionID == sessionID {
+            return
+        }
+
+        history.append(.init(sessionID: sessionID, recordedAt: date))
+        Defaults[.sessionHistory] = history
+    }
+
+    static func clear() {
+        Defaults[.sessionHistory] = []
+    }
+}

--- a/Shared/Widgets/DexcomTimelineProvider.swift
+++ b/Shared/Widgets/DexcomTimelineProvider.swift
@@ -18,6 +18,7 @@ class DexcomDelegate: DexcomClientDelegate {
 
     func didUpdateSessionID(_ sessionID: UUID) {
         Keychain.shared.sessionID = sessionID
+        DexcomSessionHistory.record(sessionID: sessionID)
     }
 }
 


### PR DESCRIPTION
## Summary
- add defaults-backed storage for Dexcom session ID history
- record session ID changes and clear history on sign out
- surface a Dexcom session history table in settings

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f70ac5317c8333896f7d49d48a3322