### PR TITLE
Ensure widget refresh records session changes

### DIFF
--- a/Shared/Widgets/DexcomTimelineProvider.swift
+++ b/Shared/Widgets/DexcomTimelineProvider.swift
@@ -42,6 +42,12 @@ extension DexcomTimelineProvider {
         return client
     }
 
+    func recordSessionIfNeeded() {
+        if let sessionID = Keychain.shared.sessionID {
+            DexcomSessionHistory.record(sessionID: sessionID)
+        }
+    }
+
     func buildTimeline<Data>(for state: GlucoseEntry<Data>.State, widgetURL: URL?) -> Timeline<GlucoseEntry<Data>> {
         let now = Date.now
 

--- a/Shared/Widgets/GraphTimelineProvider.swift
+++ b/Shared/Widgets/GraphTimelineProvider.swift
@@ -36,6 +36,7 @@ struct GraphTimelineProvider: AppIntentTimelineProvider, DexcomTimelineProvider 
 
     func timeline(for configuration: GraphWidgetConfiguration, in context: Context) async -> Timeline<Entry> {
         let state = await makeState(for: configuration)
+        recordSessionIfNeeded()
         return buildTimeline(for: state, widgetURL: configuration.app.url)
     }
 

--- a/Shared/Widgets/ReadingTimelineProvider.swift
+++ b/Shared/Widgets/ReadingTimelineProvider.swift
@@ -24,7 +24,9 @@ struct ReadingTimelineProvider: AppIntentTimelineProvider, DexcomTimelineProvide
     }
 
     func timeline(for configuration: ReadingWidgetConfiguration, in context: Context) async -> Timeline<Entry> {
-        buildTimeline(for: await makeState(for: configuration), widgetURL: configuration.url)
+        let state = await makeState(for: configuration)
+        recordSessionIfNeeded()
+        return buildTimeline(for: state, widgetURL: configuration.url)
     }
 
     func recommendations() -> [AppIntentRecommendation<ReadingWidgetConfiguration>] {


### PR DESCRIPTION
## Summary
- add a helper on the timeline provider protocol to re-record the current session id
- make the graph and reading widgets record the session after fetching new data

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7118698bc8333ab58a05666377524