### PR TITLE
Add chart scrubbing to MainView

### DIFF
--- a/Luka/Views/MainView.swift
+++ b/Luka/Views/MainView.swift
@@ -47,7 +47,7 @@ import WidgetKit
 
     private var subtitleText: String {
         if let scrubbingGlucoseReading {
-            scrubbingGlucoseReading.date.formatted(date: .abbreviated, time: .shortened)
+            scrubbingGlucoseReading.date.formatted(date: .omitted, time: .shortened)
         } else {
             liveViewModel.message
         }
@@ -85,26 +85,17 @@ import WidgetKit
                 VStack(alignment: .leading, spacing: 0) {
                     ReadingView(reading: displayReading)
                         .font(.largeTitle.weight(.semibold))
-                        .animation(.default, value: displayReading)
+                        .id(displayReading != nil)
 
                     let unit = isRedacted ? "" : "\(unit.text) • "
 
-                    VStack {
-                        Text("\(unit)\(subtitleText)")
-                    }
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .modifier { view in
-                        if isScrubbing {
-                            view.contentTransition(.identity)
-                        } else {
-                            view.contentTransition(.numericText(value: liveViewModel.messageValue))
-                        }
-                    }
-                    .animation(.default, value: subtitleText)
-                    .textCase(isScrubbing ? nil : .uppercase)
+                    Text("\(unit)\(subtitleText)")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
                 }
                 .padding([.horizontal, .bottom])
+                .animation(isScrubbing ? nil : .default, value: displayReading)
 
                 Picker("Graph range", selection: $selectedRange) {
                     ForEach(GraphRange.allCases) {
@@ -121,7 +112,6 @@ import WidgetKit
                     showAxisLabels: true,
                     useFullYRange: true,
                     selectedReading: $selectedChartReading,
-                    isScrubbable: true
                 )
                 .edgesIgnoringSafeArea(.leading)
                 .padding([.trailing, .bottom])
@@ -179,6 +169,7 @@ import WidgetKit
                 self.activity = activity
             }
         }
+        .sensoryFeedback(.selection, trigger: scrubbingGlucoseReading)
     }
 
     private func toggleLiveActivity() async {

--- a/Luka/Views/MainView.swift
+++ b/Luka/Views/MainView.swift
@@ -25,6 +25,7 @@ import WidgetKit
     @State private var activity: Activity<ReadingAttributes>? = Activity<ReadingAttributes>.activities
         .first
     @State private var isActivityLoading = false
+    @State private var selectedChartReading: LiveActivityState.Reading?
 
     private var readings: [GlucoseReading] {
         switch liveViewModel.state {
@@ -35,16 +36,32 @@ import WidgetKit
         }
     }
 
-    private var readingText: String {
-        switch liveViewModel.state {
-        case .initial, .noRecentReading, .error:
-            return "100"
-        case .loaded(_, let latest):
-            return latest.value.formatted(.glucose(unit))
+    private var scrubbingGlucoseReading: GlucoseReading? {
+        guard let selectedChartReading else { return nil }
+        return readings.first { $0.date == selectedChartReading.t }
+    }
+
+    private var displayReading: GlucoseReading? {
+        scrubbingGlucoseReading ?? readings.last
+    }
+
+    private var subtitleText: String {
+        if let scrubbingGlucoseReading {
+            scrubbingGlucoseReading.date.formatted(date: .abbreviated, time: .shortened)
+        } else {
+            liveViewModel.message
         }
     }
 
+    private var isScrubbing: Bool {
+        scrubbingGlucoseReading != nil
+    }
+
     private var isRedacted: Bool {
+        if isScrubbing {
+            return false
+        }
+
         switch liveViewModel.state {
         case .initial:
             return true
@@ -66,20 +83,26 @@ import WidgetKit
         NavigationStack {
             VStack(alignment: .leading) {
                 VStack(alignment: .leading, spacing: 0) {
-                    ReadingView(reading: readings.last)
+                    ReadingView(reading: displayReading)
                         .font(.largeTitle.weight(.semibold))
-                        .animation(.default, value: readings.last)
+                        .animation(.default, value: displayReading)
 
                     let unit = isRedacted ? "" : "\(unit.text) • "
 
                     VStack {
-                        Text("\(unit)\(liveViewModel.message)")
+                        Text("\(unit)\(subtitleText)")
                     }
                     .font(.caption2.weight(.medium))
                     .foregroundStyle(.secondary)
-                    .contentTransition(.numericText(value: liveViewModel.messageValue))
-                    .animation(.default, value: liveViewModel.message)
-                    .textCase(.uppercase)
+                    .modifier { view in
+                        if isScrubbing {
+                            view.contentTransition(.identity)
+                        } else {
+                            view.contentTransition(.numericText(value: liveViewModel.messageValue))
+                        }
+                    }
+                    .animation(.default, value: subtitleText)
+                    .textCase(isScrubbing ? nil : .uppercase)
                 }
                 .padding([.horizontal, .bottom])
 
@@ -96,7 +119,9 @@ import WidgetKit
                     range: selectedRange,
                     readings: readings.toLiveActivityReadings(),
                     showAxisLabels: true,
-                    useFullYRange: true
+                    useFullYRange: true,
+                    selectedReading: $selectedChartReading,
+                    isScrubbable: true
                 )
                 .edgesIgnoringSafeArea(.leading)
                 .padding([.trailing, .bottom])

--- a/Shared/Views/ReadingView.swift
+++ b/Shared/Views/ReadingView.swift
@@ -39,7 +39,6 @@ struct ReadingView: View {
         .contentTransition(.numericText(value: Double(reading?.value ?? 0)))
         .redacted(reason: reading == nil ? .placeholder : [])
         .imageScale(.small)
-        .animation(.default, value: reading)
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional scrubbing support to the shared line chart without affecting existing widget or live activity usage
- update the iOS MainView to surface the selected reading and timestamp while scrubbing the chart

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690c193a18948333b1c5bdb3a00d851d