### PR TITLE
Add launch tracking and rating prompt after 10 launches

### DIFF
--- a/Luka/LukaApp.swift
+++ b/Luka/LukaApp.swift
@@ -41,7 +41,7 @@ struct LukaApp: App {
                 })
                 .task {
                     // Request review after 10 launches
-                    if Defaults[.launchCount] == 10 {
+                    if Defaults[.launchCount] >= 10 {
                         requestReview()
                     }
                 }

--- a/Luka/LukaApp.swift
+++ b/Luka/LukaApp.swift
@@ -9,11 +9,13 @@ import SwiftUI
 import WidgetKit
 import TelemetryDeck
 import Defaults
+import StoreKit
 
 @main
 struct LukaApp: App {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.requestReview) private var requestReview
 
     @State private var viewModel = RootViewModel()
 
@@ -26,6 +28,9 @@ struct LukaApp: App {
         #if DEBUG
         Defaults[.dismissedBannerIDs] = []
         #endif
+
+        // Increment launch count
+        Defaults[.launchCount] += 1
     }
 
     var body: some Scene {
@@ -34,6 +39,12 @@ struct LukaApp: App {
                 .onOpenURL(perform: { url in
                     openURL(url)
                 })
+                .task {
+                    // Request review after 10 launches
+                    if Defaults[.launchCount] == 10 {
+                        requestReview()
+                    }
+                }
         }
         .onChange(of: scenePhase) {
             if scenePhase == .background {

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -29,6 +29,7 @@ extension Defaults.Keys {
         suite: .shared,
         iCloud: true
     )
+    static let launchCount = Key<Int>("launchCount", default: 0, suite: .shared, iCloud: true)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
- Add launchCount to Defaults with iCloud sync
- Increment launch count on app initialization
- Request system rating prompt when launch count reaches 10
- Uses StoreKit's requestReview environment action