### PR TITLE
Fix chart safe area in landscape mode

### DIFF
--- a/Luka/Views/MainView.swift
+++ b/Luka/Views/MainView.swift
@@ -134,8 +134,8 @@ import WidgetKit
                     useFullYRange: true,
                     selectedReading: $selectedChartReading,
                 )
-                .edgesIgnoringSafeArea(.leading)
-                .padding([.trailing, .bottom])
+                .padding(.horizontal)
+                .padding(.bottom)
 
                 if !isCompact {
                     liveActivityButton()

--- a/Luka/Views/MainView.swift
+++ b/Luka/Views/MainView.swift
@@ -134,7 +134,7 @@ import WidgetKit
                     useFullYRange: true,
                     selectedReading: $selectedChartReading,
                 )
-                .padding(.horizontal)
+                .padding(.trailing)
                 .padding(.bottom)
 
                 if !isCompact {


### PR DESCRIPTION
Remove edgesIgnoringSafeArea(.leading) from LineChart to prevent
chart from extending into horizontal safe area in landscape mode,
especially on devices with notches or Dynamic Island.