### PR TITLE
Improve chart scrubbing UX by clamping to closest value

### DIFF
--- a/Shared/Views/LineChart.swift
+++ b/Shared/Views/LineChart.swift
@@ -176,12 +176,11 @@ struct LineChart: View {
 
                                     guard let plotFrame = proxy.plotFrame else { return }
                                     let frame = geometry[plotFrame]
-                                    guard frame.contains(value.location) else {
-                                        selectedReading.wrappedValue = nil
-                                        return
-                                    }
 
-                                    let xPosition = value.location.x - frame.origin.x
+                                    // Clamp the x position to the frame bounds instead of returning nil
+                                    let rawXPosition = value.location.x - frame.origin.x
+                                    let xPosition = max(0, min(rawXPosition, frame.width))
+
                                     if let date: Date = proxy.value(atX: xPosition, as: Date.self) {
                                         selectedReading.wrappedValue = readingClosest(to: date)
                                     }


### PR DESCRIPTION
Previously, dragging off the chart (horizontally or vertically) would
set the selected reading to nil, causing the value to disappear and
then reappear when dragging back onto the chart.

Now the x position is clamped to the chart bounds, so:
- Dragging past the right edge shows the most recent reading
- Dragging past the left edge shows the oldest reading
- Dragging vertically off still tracks horizontally

This provides a smoother scrubbing experience without null values.