### PR TITLE
Remove foreground mode requirement to support iOS 18

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -606,7 +606,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -632,7 +632,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -658,7 +658,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -686,7 +686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -715,7 +715,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -744,7 +744,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -903,7 +903,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -932,7 +932,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Shared/Intents/ToggleLiveActivityIntent.swift
+++ b/Shared/Intents/ToggleLiveActivityIntent.swift
@@ -8,11 +8,10 @@
 import ActivityKit
 import AppIntents
 
-@available(iOS 26.0, *)
+@available(iOS 18.0, *)
 struct ToggleLiveActivityIntent: SetValueIntent, LiveActivityIntent {
     static let title: LocalizedStringResource = "Toggle Live Activity"
     static let description = IntentDescription("Start or stop the glucose Live Activity.")
-    static let supportedModes: IntentModes = .foreground(.dynamic)
 
     @Parameter(title: "Running")
     var value: Bool

--- a/Shared/Widgets/LiveActivityControl.swift
+++ b/Shared/Widgets/LiveActivityControl.swift
@@ -9,7 +9,7 @@ import Defaults
 import SwiftUI
 import WidgetKit
 
-@available(iOS 26.0, *)
+@available(iOS 18.0, *)
 struct LiveActivityControl: ControlWidget {
     static let kind = "com.kylebashour.Glimpse.LiveActivityControl"
 
@@ -28,7 +28,7 @@ struct LiveActivityControl: ControlWidget {
     }
 }
 
-@available(iOS 26.0, *)
+@available(iOS 18.0, *)
 extension LiveActivityControl {
     struct Provider: ControlValueProvider {
         var previewValue: Bool { false }

--- a/Shared/Widgets/LukaWidgetBundle.swift
+++ b/Shared/Widgets/LukaWidgetBundle.swift
@@ -15,7 +15,7 @@ struct LukaWidgetBundle: WidgetBundle {
         ReadingWidget()
         #if os(iOS)
         ReadingActivityConfiguration()
-        if #available(iOS 26.0, *) {
+        if #available(iOS 18.0, *) {
             LiveActivityControl()
         }
         #endif


### PR DESCRIPTION
Removed .foreground(.dynamic) mode from ToggleLiveActivityIntent and updated iOS availability from 26.0 to 18.0 for LiveActivityControl. This allows the Control Center widget to work on iOS 18+.