### PR TITLE
Add accent color tint to Live Activity control widget

### DIFF
--- a/LukaWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/LukaWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,33 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x76",
+          "red" : "0x3C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.286",
+          "green" : "0.726",
+          "red" : "0.355"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Shared/Widgets/LiveActivityControl.swift
+++ b/Shared/Widgets/LiveActivityControl.swift
@@ -22,6 +22,7 @@ struct LiveActivityControl: ControlWidget {
             ) { isOn in
                 Label(isOn ? "On" : "Off", systemImage: "arrow.right")
             }
+            .tint(.accentColor)
         }
         .displayName("Live Activity")
         .description("Toggle your glucose Live Activity.")


### PR DESCRIPTION
Copy AccentColor asset to widget extension and apply .tint(.accentColor)
to the ControlWidgetToggle for consistent branding.