### PR TITLE
Add String Catalog for modern app localization

### DIFF
--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -87,10 +87,10 @@ struct SettingsView: View {
                 }
             } header: {
                 if let username {
-                    Text("Signed in as \(username)")
+                    Text("Signed in as \(username)", comment: "Settings section header showing current user")
                 }
             } footer: {
-                Text("Version \(Bundle.main.fullVersion)")
+                Text("Version \(Bundle.main.fullVersion)", comment: "Settings footer showing app version")
                     .font(.footnote.weight(.medium))
                     .fontDesign(.monospaced)
                     .foregroundStyle(.secondary)

--- a/Luka/Views/SignInView.swift
+++ b/Luka/Views/SignInView.swift
@@ -104,11 +104,11 @@ extension AccountLocation: @retroactive Identifiable {
     var displayName: String {
         switch self {
         case .usa:
-            "United States"
+            String(localized: "United States")
         case .apac:
-            "Japan"
+            String(localized: "Japan")
         case .worldwide:
-            "Anywhere Else"
+            String(localized: "Anywhere Else")
         }
     }
 }

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -26,7 +26,7 @@ struct ReadingActivityConfiguration: Widget {
                     HStack(spacing: 0) {
                         context.timestamp
                         if !context.isStale {
-                            Text(" • Last \(context.attributes.range.abbreviatedName)")
+                            Text(" • Last \(context.attributes.range.abbreviatedName)", comment: "Live Activity label showing graph range")
                         }
                     }
                     .font(.caption2.bold())
@@ -210,7 +210,7 @@ private struct MainContentView: View {
                         context.timestamp
                         if showChartLiveActivity {
                             if context.state.c != nil, !context.isStale {
-                                Text("Last \(context.attributes.range.abbreviatedName)")
+                                Text("Last \(context.attributes.range.abbreviatedName)", comment: "Live Activity label showing graph range")
                             }
                         }
                     }
@@ -328,14 +328,14 @@ private struct GraphPieceView: View {
 
 private extension ActivityViewContext<ReadingAttributes> {
     var timestamp: Text {
-        let offlineText = Text("Offline").foregroundStyle(.red)
+        let offlineText = Text("Offline", comment: "Status indicator when Live Activity is not receiving updates").foregroundStyle(.red)
 
         if let current = state.c {
             if isStale {
                 let lastReading = current.date.formatted(date: .omitted, time: .shortened)
-                return Text("\(offlineText) at \(lastReading)")
+                return Text("Offline at \(lastReading)", comment: "Status showing last update time when offline").foregroundStyle(.red)
             } else {
-                return Text("Live").foregroundStyle(.green)
+                return Text("Live", comment: "Status indicator when Live Activity is receiving updates").foregroundStyle(.green)
             }
         } else {
             return offlineText

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings" : {
     "" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14,6 +20,12 @@
     "%@ ago" : {
       "comment" : "Relative time suffix, e.g. '5 min ago'",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vor %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25,6 +37,12 @@
     "Anywhere Else" : {
       "comment" : "Account location option for users outside US and Japan",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anderswo"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36,6 +54,12 @@
     "Done" : {
       "comment" : "Button to dismiss settings",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -47,6 +71,12 @@
     "Email Me" : {
       "comment" : "Settings row to contact developer",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-Mail senden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58,6 +88,12 @@
     "End Live Activity" : {
       "comment" : "Button to stop Live Activity",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivität beenden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69,6 +105,12 @@
     "Excellent widgets and Live Activities for Dexcom continuous glucose monitors." : {
       "comment" : "App tagline on sign-in screen",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hervorragende Widgets und Live-Aktivitäten für Dexcom-Glukosemessgeräte."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -80,6 +122,12 @@
     "General" : {
       "comment" : "Settings section header",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allgemein"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -91,6 +139,12 @@
     "Graph range" : {
       "comment" : "Picker label for selecting graph time range",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diagrammbereich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -102,6 +156,12 @@
     "Graphs" : {
       "comment" : "Settings section header for graph options",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diagramme"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -113,6 +173,12 @@
     "Japan" : {
       "comment" : "Account location option for Japan/APAC region",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japan"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -124,6 +190,12 @@
     "Just now" : {
       "comment" : "Timestamp for very recent readings",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerade eben"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -135,6 +207,12 @@
     "Last %@" : {
       "comment" : "Live Activity label showing graph range, e.g. 'Last 3H'",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -146,6 +224,12 @@
     "Leave a Review" : {
       "comment" : "Settings row to leave App Store review",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewertung schreiben"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -157,6 +241,12 @@
     "Live" : {
       "comment" : "Status indicator when Live Activity is receiving updates",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -168,6 +258,12 @@
     "Live Activity ended" : {
       "comment" : "Message shown when Live Activity has expired",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivität beendet"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -179,6 +275,12 @@
     "Lower target range" : {
       "comment" : "Settings slider title for low glucose threshold",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterer Zielbereich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -190,6 +292,12 @@
     "Luka for macOS" : {
       "comment" : "Settings row to share macOS app",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luka für macOS"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -201,6 +309,12 @@
     "Network Error" : {
       "comment" : "Widget error when unable to fetch data",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerkfehler"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -212,6 +326,12 @@
     "No Account" : {
       "comment" : "Widget error when user is not signed in",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Konto"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -223,6 +343,12 @@
     "No Recent Readings" : {
       "comment" : "Widget error when no recent glucose data available",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine aktuellen Werte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -234,6 +360,12 @@
     "Now" : {
       "comment" : "Short timestamp for very recent readings",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -245,6 +377,12 @@
     "Offline" : {
       "comment" : "Status indicator when Live Activity is not receiving updates",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -256,6 +394,12 @@
     "Offline at %@" : {
       "comment" : "Status showing last update time when offline",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline seit %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -267,6 +411,12 @@
     "OK" : {
       "comment" : "Alert dismiss button",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -278,6 +428,12 @@
     "Password" : {
       "comment" : "Password text field placeholder",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -289,6 +445,12 @@
     "Reload" : {
       "comment" : "Widget button to refresh data",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu laden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -300,6 +462,12 @@
     "Restart" : {
       "comment" : "Button to restart Live Activity",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neustart"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -311,6 +479,12 @@
     "Select an account location to get started" : {
       "comment" : "Instruction on sign-in screen",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle einen Kontostandort aus, um zu beginnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -322,6 +496,12 @@
     "Settings" : {
       "comment" : "Navigation title and toolbar button",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -333,6 +513,12 @@
     "Share Luka" : {
       "comment" : "Settings row to share the app",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luka teilen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -344,6 +530,12 @@
     "Show Graph in Live Activity" : {
       "comment" : "Settings toggle for Live Activity graph",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diagramm in Live-Aktivität anzeigen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -355,6 +547,12 @@
     "Sign In" : {
       "comment" : "Navigation title and button label",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmelden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -366,6 +564,12 @@
     "Sign in using your Dexcom username and password. **Dexcom share must be enabled with at least one follower**, but sign in using **your own Dexcom credentials**, not the followers. If your username is a phone number, format it with a + and the area code, for example +12223334444." : {
       "comment" : "Help text explaining sign-in requirements",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich mit deinem Dexcom-Benutzernamen und Passwort an. **Dexcom Share muss mit mindestens einem Follower aktiviert sein**, aber melde dich mit **deinen eigenen Dexcom-Zugangsdaten** an, nicht mit denen der Follower. Wenn dein Benutzername eine Telefonnummer ist, formatiere sie mit + und Vorwahl, zum Beispiel +4917012345678."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -377,6 +581,12 @@
     "Sign Out" : {
       "comment" : "Button to sign out of account",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abmelden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -388,6 +598,12 @@
     "Signed in as %@" : {
       "comment" : "Settings section header showing current user",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angemeldet als %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -399,6 +615,12 @@
     "Something Went Wrong" : {
       "comment" : "Alert title for sign-in error",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etwas ist schiefgelaufen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -410,6 +632,12 @@
     "Start Live Activity" : {
       "comment" : "Button to start Live Activity",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivität starten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -421,6 +649,12 @@
     "This version of Luka is no longer supported. Please update to continue." : {
       "comment" : "Force upgrade message",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Version von Luka wird nicht mehr unterstützt. Bitte aktualisiere die App, um fortzufahren."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -432,6 +666,12 @@
     "Toggle Live Activity" : {
       "comment" : "Accessibility label for Live Activity button",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivität umschalten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -443,6 +683,12 @@
     "Try again in a few minutes" : {
       "comment" : "Alert message for sign-in error",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versuche es in ein paar Minuten erneut"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -454,6 +700,12 @@
     "United States" : {
       "comment" : "Account location option for US users",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vereinigte Staaten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -465,6 +717,12 @@
     "Units" : {
       "comment" : "Settings picker label for glucose units",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einheiten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -476,6 +734,12 @@
     "Update Now" : {
       "comment" : "Button to open App Store for update",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt aktualisieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -487,6 +751,12 @@
     "Update Required" : {
       "comment" : "Force upgrade screen title",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisierung erforderlich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -498,6 +768,12 @@
     "Upper bound" : {
       "comment" : "Settings slider title for graph upper limit",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obergrenze"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -509,6 +785,12 @@
     "Upper target range" : {
       "comment" : "Settings slider title for high glucose threshold",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oberer Zielbereich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -520,6 +802,12 @@
     "Username" : {
       "comment" : "Username text field placeholder",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzername"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -531,6 +819,12 @@
     "Version %@" : {
       "comment" : "Settings footer showing app version",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -542,6 +836,12 @@
     "Welcome to" : {
       "comment" : "Welcome message prefix before app name",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen bei"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1,0 +1,555 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "%@ ago" : {
+      "comment" : "Relative time suffix, e.g. '5 min ago'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ago"
+          }
+        }
+      }
+    },
+    "Anywhere Else" : {
+      "comment" : "Account location option for users outside US and Japan",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anywhere Else"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "comment" : "Button to dismiss settings",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "Email Me" : {
+      "comment" : "Settings row to contact developer",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email Me"
+          }
+        }
+      }
+    },
+    "End Live Activity" : {
+      "comment" : "Button to stop Live Activity",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End Live Activity"
+          }
+        }
+      }
+    },
+    "Excellent widgets and Live Activities for Dexcom continuous glucose monitors." : {
+      "comment" : "App tagline on sign-in screen",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excellent widgets and Live Activities for Dexcom continuous glucose monitors."
+          }
+        }
+      }
+    },
+    "General" : {
+      "comment" : "Settings section header",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        }
+      }
+    },
+    "Graph range" : {
+      "comment" : "Picker label for selecting graph time range",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graph range"
+          }
+        }
+      }
+    },
+    "Graphs" : {
+      "comment" : "Settings section header for graph options",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graphs"
+          }
+        }
+      }
+    },
+    "Japan" : {
+      "comment" : "Account location option for Japan/APAC region",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japan"
+          }
+        }
+      }
+    },
+    "Just now" : {
+      "comment" : "Timestamp for very recent readings",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Just now"
+          }
+        }
+      }
+    },
+    "Last %@" : {
+      "comment" : "Live Activity label showing graph range, e.g. 'Last 3H'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last %@"
+          }
+        }
+      }
+    },
+    "Leave a Review" : {
+      "comment" : "Settings row to leave App Store review",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leave a Review"
+          }
+        }
+      }
+    },
+    "Live" : {
+      "comment" : "Status indicator when Live Activity is receiving updates",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live"
+          }
+        }
+      }
+    },
+    "Live Activity ended" : {
+      "comment" : "Message shown when Live Activity has expired",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity ended"
+          }
+        }
+      }
+    },
+    "Lower target range" : {
+      "comment" : "Settings slider title for low glucose threshold",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lower target range"
+          }
+        }
+      }
+    },
+    "Luka for macOS" : {
+      "comment" : "Settings row to share macOS app",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luka for macOS"
+          }
+        }
+      }
+    },
+    "Network Error" : {
+      "comment" : "Widget error when unable to fetch data",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Error"
+          }
+        }
+      }
+    },
+    "No Account" : {
+      "comment" : "Widget error when user is not signed in",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Account"
+          }
+        }
+      }
+    },
+    "No Recent Readings" : {
+      "comment" : "Widget error when no recent glucose data available",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Recent Readings"
+          }
+        }
+      }
+    },
+    "Now" : {
+      "comment" : "Short timestamp for very recent readings",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Now"
+          }
+        }
+      }
+    },
+    "Offline" : {
+      "comment" : "Status indicator when Live Activity is not receiving updates",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        }
+      }
+    },
+    "Offline at %@" : {
+      "comment" : "Status showing last update time when offline",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline at %@"
+          }
+        }
+      }
+    },
+    "OK" : {
+      "comment" : "Alert dismiss button",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "Password" : {
+      "comment" : "Password text field placeholder",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        }
+      }
+    },
+    "Reload" : {
+      "comment" : "Widget button to refresh data",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reload"
+          }
+        }
+      }
+    },
+    "Restart" : {
+      "comment" : "Button to restart Live Activity",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart"
+          }
+        }
+      }
+    },
+    "Select an account location to get started" : {
+      "comment" : "Instruction on sign-in screen",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an account location to get started"
+          }
+        }
+      }
+    },
+    "Settings" : {
+      "comment" : "Navigation title and toolbar button",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "Share Luka" : {
+      "comment" : "Settings row to share the app",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Luka"
+          }
+        }
+      }
+    },
+    "Show Graph in Live Activity" : {
+      "comment" : "Settings toggle for Live Activity graph",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Graph in Live Activity"
+          }
+        }
+      }
+    },
+    "Sign In" : {
+      "comment" : "Navigation title and button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign In"
+          }
+        }
+      }
+    },
+    "Sign in using your Dexcom username and password. **Dexcom share must be enabled with at least one follower**, but sign in using **your own Dexcom credentials**, not the followers. If your username is a phone number, format it with a + and the area code, for example +12223334444." : {
+      "comment" : "Help text explaining sign-in requirements",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in using your Dexcom username and password. **Dexcom share must be enabled with at least one follower**, but sign in using **your own Dexcom credentials**, not the followers. If your username is a phone number, format it with a + and the area code, for example +12223334444."
+          }
+        }
+      }
+    },
+    "Sign Out" : {
+      "comment" : "Button to sign out of account",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign Out"
+          }
+        }
+      }
+    },
+    "Signed in as %@" : {
+      "comment" : "Settings section header showing current user",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signed in as %@"
+          }
+        }
+      }
+    },
+    "Something Went Wrong" : {
+      "comment" : "Alert title for sign-in error",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
+          }
+        }
+      }
+    },
+    "Start Live Activity" : {
+      "comment" : "Button to start Live Activity",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Live Activity"
+          }
+        }
+      }
+    },
+    "This version of Luka is no longer supported. Please update to continue." : {
+      "comment" : "Force upgrade message",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This version of Luka is no longer supported. Please update to continue."
+          }
+        }
+      }
+    },
+    "Toggle Live Activity" : {
+      "comment" : "Accessibility label for Live Activity button",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Live Activity"
+          }
+        }
+      }
+    },
+    "Try again in a few minutes" : {
+      "comment" : "Alert message for sign-in error",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again in a few minutes"
+          }
+        }
+      }
+    },
+    "United States" : {
+      "comment" : "Account location option for US users",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "United States"
+          }
+        }
+      }
+    },
+    "Units" : {
+      "comment" : "Settings picker label for glucose units",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Units"
+          }
+        }
+      }
+    },
+    "Update Now" : {
+      "comment" : "Button to open App Store for update",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Now"
+          }
+        }
+      }
+    },
+    "Update Required" : {
+      "comment" : "Force upgrade screen title",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Required"
+          }
+        }
+      }
+    },
+    "Upper bound" : {
+      "comment" : "Settings slider title for graph upper limit",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upper bound"
+          }
+        }
+      }
+    },
+    "Upper target range" : {
+      "comment" : "Settings slider title for high glucose threshold",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upper target range"
+          }
+        }
+      }
+    },
+    "Username" : {
+      "comment" : "Username text field placeholder",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Username"
+          }
+        }
+      }
+    },
+    "Version %@" : {
+      "comment" : "Settings footer showing app version",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %@"
+          }
+        }
+      }
+    },
+    "Welcome to" : {
+      "comment" : "Welcome message prefix before app name",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome to"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Shared/Utilities/GlucoseReading+Extensions.swift
+++ b/Shared/Utilities/GlucoseReading+Extensions.swift
@@ -56,16 +56,16 @@ extension GlucoseReading {
             if let nowText {
                 return nowText
             } else if appendRelativeText {
-                return "Just now"
+                return String(localized: "Just now")
             } else {
-                return "Now"
+                return String(localized: "Now")
             }
         } else {
             let formatter = formatter(style: style)
             let text = formatter.string(from: date, to: currentDate)!
 
             if appendRelativeText {
-                return text + " ago"
+                return String(localized: "\(text) ago", comment: "Relative time suffix, e.g. '5 min ago'")
             } else {
                 return text
             }

--- a/Shared/Widgets/GlucoseEntry.swift
+++ b/Shared/Widgets/GlucoseEntry.swift
@@ -54,9 +54,9 @@ extension GlucoseEntryError {
     var buttonText: String {
         switch self {
         case .loggedOut:
-            "Sign In"
+            String(localized: "Sign In")
         case .failedToLoad, .noRecentReadings:
-            "Reload"
+            String(localized: "Reload")
         }
     }
 
@@ -74,11 +74,11 @@ extension GlucoseEntryError {
     var description: String {
         switch self {
         case .loggedOut:
-            "No Account"
+            String(localized: "No Account")
         case .noRecentReadings:
-            "No Recent Readings"
+            String(localized: "No Recent Readings")
         case .failedToLoad:
-            "Network Error"
+            String(localized: "Network Error")
         }
     }
 }


### PR DESCRIPTION
- Create Localizable.xcstrings in Shared folder with all UI strings
- Update AccountLocation.displayName to use String(localized:)
- Update GlucoseEntryError.description and buttonText with localization
- Update GlucoseReading.timestamp to use localized strings
- Add localization comments to Live Activity Text views
- Add localization comments to Settings section headers/footers

SwiftUI Text views automatically extract strings to the catalog.
The project is now ready for adding additional languages.