### PR TITLE
Increase saturation on Live Activity graph glow

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -316,6 +316,7 @@ private struct GraphPieceView: View {
     var body: some View {
         ZStack {
             LineChart(range: context.attributes.range, readings: context.state.h, lineWidth: 15)
+                .saturation(2)
                 .blur(radius: 30)
                 .opacity(0.85)
             LineChart(range: context.attributes.range, readings: context.state.h)


### PR DESCRIPTION
## Summary
- Boost the blurred graph glow effect from default saturation to 2x for more vibrant colors in the Live Activity chart

## Test plan
- [ ] Run Live Activity and verify the graph glow appears more colorful/vibrant

🤖 Generated with [Claude Code](https://claude.com/claude-code)