### PR TITLE
Add detailed parameters to live activity API telemetry

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -147,6 +147,11 @@ final class LiveActivityManager {
         request.httpBody = try! encoder.encode(payload)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        dateFormatter.timeZone = .current
+        let dateTimeString = dateFormatter.string(from: Date())
+
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             let httpResponse = response as? HTTPURLResponse
@@ -155,14 +160,16 @@ final class LiveActivityManager {
             TelemetryDeck.signal(
                 "LiveActivity.sentToken",
                 parameters: [
-                    "statusCode": "\(statusCode)"
+                    "statusCode": "\(statusCode)",
+                    "dateTime": dateTimeString
                 ]
             )
         } catch {
             TelemetryDeck.signal(
                 "LiveActivity.failedToSendToken",
                 parameters: [
-                    "error": error.localizedDescription
+                    "error": error.localizedDescription,
+                    "dateTime": dateTimeString
                 ]
             )
         }
@@ -181,6 +188,11 @@ final class LiveActivityManager {
         request.httpBody = try! encoder.encode(payload)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        dateFormatter.timeZone = .current
+        let dateTimeString = dateFormatter.string(from: Date())
+
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             let httpResponse = response as? HTTPURLResponse
@@ -189,14 +201,16 @@ final class LiveActivityManager {
             TelemetryDeck.signal(
                 "LiveActivity.sentEnd",
                 parameters: [
-                    "statusCode": "\(statusCode)"
+                    "statusCode": "\(statusCode)",
+                    "dateTime": dateTimeString
                 ]
             )
         } catch {
             TelemetryDeck.signal(
                 "LiveActivity.failedToSendEnd",
                 parameters: [
-                    "error": error.localizedDescription
+                    "error": error.localizedDescription,
+                    "dateTime": dateTimeString
                 ]
             )
         }

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -148,10 +148,23 @@ final class LiveActivityManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            _ = try await URLSession.shared.data(for: request)
-            TelemetryDeck.signal("LiveActivity.sentToken")
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = response as? HTTPURLResponse
+            let statusCode = httpResponse?.statusCode ?? -1
+
+            TelemetryDeck.signal(
+                "LiveActivity.sentToken",
+                parameters: [
+                    "statusCode": "\(statusCode)"
+                ]
+            )
         } catch {
-            TelemetryDeck.signal("LiveActivity.failedToSendToken")
+            TelemetryDeck.signal(
+                "LiveActivity.failedToSendToken",
+                parameters: [
+                    "error": error.localizedDescription
+                ]
+            )
         }
     }
 
@@ -169,10 +182,23 @@ final class LiveActivityManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            _ = try await URLSession.shared.data(for: request)
-            TelemetryDeck.signal("LiveActivity.sentEnd")
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = response as? HTTPURLResponse
+            let statusCode = httpResponse?.statusCode ?? -1
+
+            TelemetryDeck.signal(
+                "LiveActivity.sentEnd",
+                parameters: [
+                    "statusCode": "\(statusCode)"
+                ]
+            )
         } catch {
-            TelemetryDeck.signal("LiveActivity.failedToSendEnd")
+            TelemetryDeck.signal(
+                "LiveActivity.failedToSendEnd",
+                parameters: [
+                    "error": error.localizedDescription
+                ]
+            )
         }
     }
 }


### PR DESCRIPTION
Add HTTP status code to success signals and error description
to failure signals for sendStartLiveActivity and sendEndLiveActivity
API calls, making them consistent with other telemetry signals.