### PR TITLE
Add accessoryCorner support to reading widget on watchOS

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -691,7 +691,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -717,7 +717,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -743,7 +743,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -771,7 +771,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -800,7 +800,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -829,7 +829,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1034,7 +1034,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1063,7 +1063,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Shared/Widgets/ReadingWidget.swift
+++ b/Shared/Widgets/ReadingWidget.swift
@@ -29,6 +29,7 @@ struct ReadingWidget: Widget {
         [
             .accessoryInline,
             .accessoryCircular,
+            .accessoryCorner,
         ]
         #else
         [

--- a/Shared/Widgets/Views/CornerWidgetErrorView.swift
+++ b/Shared/Widgets/Views/CornerWidgetErrorView.swift
@@ -1,0 +1,24 @@
+//
+//  CornerWidgetErrorView.swift
+//  Luka
+//
+//  Created by Kyle Bashour on 4/18/26.
+//
+
+import SwiftUI
+
+struct CornerWidgetErrorView: View {
+    let error: GlucoseEntryError
+
+    var body: some View {
+        Button(intent: ReloadWidgetIntent()) {
+            Image(systemName: error.image)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .invalidatableContent()
+                .widgetLabel(error.description)
+        }
+        .buttonStyle(.plain)
+        .containerBackground(.background, for: .widget)
+    }
+}

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -1,0 +1,53 @@
+//
+//  CornerWidgetReadingView.swift
+//  Luka
+//
+//  Created by Kyle Bashour on 4/18/26.
+//
+
+import Dexcom
+import SwiftUI
+import WidgetKit
+import Defaults
+
+struct CornerWidgetView: View {
+    let entry: ReadingTimelineProvider.Entry
+    let reading: GlucoseReading
+
+    @Environment(\.redactionReasons) private var redactionReasons
+
+    @Default(.targetRangeLowerBound) private var targetLower
+    @Default(.targetRangeUpperBound) private var targetUpper
+    @Default(.unit) private var unit
+
+    var body: some View {
+        Group {
+            if entry.widgetURL == nil {
+                Button(intent: ReloadWidgetIntent()) {
+                    content
+                }
+            } else {
+                content
+            }
+        }
+        .buttonStyle(.plain)
+        .containerBackground(.background, for: .widget)
+    }
+
+    private var content: some View {
+        Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
+            .font(.title3)
+            .fontWeight(.bold)
+            .fontDesign(.rounded)
+            .invalidatableContent()
+            .foregroundStyle(reading.color(target: targetLower...targetUpper))
+            .widgetLabel {
+                HStack(spacing: 2) {
+                    if redactionReasons.isEmpty, let image = reading.image {
+                        image
+                    }
+                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false).localizedLowercase)
+                }
+            }
+    }
+}

--- a/Shared/Widgets/Views/ReadingWidgetView.swift
+++ b/Shared/Widgets/Views/ReadingWidgetView.swift
@@ -33,6 +33,10 @@ struct ReadingWidgetView: View {
             InlineWidgetReadingView(entry: entry, reading: reading)
         case .accessoryCircular:
             CircularWidgetView(entry: entry, reading: reading)
+        #if os(watchOS)
+        case .accessoryCorner:
+            CornerWidgetView(entry: entry, reading: reading)
+        #endif
         default:
             fatalError()
         }

--- a/Shared/Widgets/Views/WidgetErrorView.swift
+++ b/Shared/Widgets/Views/WidgetErrorView.swift
@@ -22,6 +22,10 @@ struct WidgetErrorView: View {
             RectangularWidgetErrorView(error: error)
         case .accessoryCircular:
             CircularWidgetErrorView(imageName: error.image)
+        #if os(watchOS)
+        case .accessoryCorner:
+            CornerWidgetErrorView(error: error)
+        #endif
         default:
             fatalError()
         }


### PR DESCRIPTION
Renders the glucose value at the corner of the Infograph watch face with
the trend arrow and timestamp along the curved bezel label. Mirrors the
redaction behavior of the accessoryCircular widget.