### PR TITLE
Render corner widget label as a single text string

### DIFF
--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -42,12 +42,22 @@ struct CornerWidgetView: View {
             .invalidatableContent()
             .foregroundStyle(reading.color(target: targetLower...targetUpper))
             .widgetLabel {
-                HStack(spacing: 2) {
-                    if redactionReasons.isEmpty, let image = reading.image {
-                        image
-                    }
-                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false).localizedLowercase)
-                }
+                label
             }
+    }
+
+    private var label: Text {
+        let value = redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80"
+        let timestamp = reading.timestamp(
+            for: entry.date,
+            style: .abbreviated,
+            appendRelativeText: false
+        ).localizedLowercase
+
+        if redactionReasons.isEmpty, let image = reading.image {
+            return Text("\(value) \(image) \(timestamp)")
+        } else {
+            return Text("\(value) \(timestamp)")
+        }
     }
 }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -35,14 +35,13 @@ struct CornerWidgetView: View {
     }
 
     private var content: some View {
-        Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
-            .font(.title3)
-            .fontWeight(.bold)
-            .fontDesign(.rounded)
-            .invalidatableContent()
-            .foregroundStyle(reading.color(target: targetLower...targetUpper))
+        Color.clear
             .widgetLabel {
                 label
+                    .fontWeight(.bold)
+                    .fontDesign(.rounded)
+                    .invalidatableContent()
+                    .foregroundStyle(reading.color(target: targetLower...targetUpper))
             }
     }
 


### PR DESCRIPTION
## Summary
- Combines the glucose value, trend arrow image, and timestamp into a single `Text` inside `.widgetLabel` so the full string (e.g. `142 ↗ 4M`) curves together along the Infograph bezel instead of rendering as separate views.
- Interpolates `reading.image` directly into the `Text`, reusing the existing trend arrow assets/SF Symbols.
- Redaction still matches `.accessoryCircular`: shows `80` as the placeholder value and drops the arrow when the entry is expired.

## Test plan
- [ ] Add the corner complication to an Infograph watch face and confirm the text curves along the bezel as one string.
- [ ] Verify the arrow updates for each `TrendDirection` (single/double up/down, 45°, flat).
- [ ] Let a reading go stale (>25 min) and confirm the label shows `80 {time}` with no arrow.

https://claude.ai/code/session_013UvSjnDWgVMrYYM8TK6bnC