### PR TITLE
Add target range gauge to corner widget label

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 				"Utilities/EdgeInsets+Extensions.swift",
 				"Utilities/View+Modifier.swift",
 				"View Models/LiveViewModel.swift",
+				Widgets/Views/CornerWidgetReadingView.swift,
 			);
 			target = 2703324C2BD99E90009535EE /* LukaWidget */;
 		};

--- a/Shared/Widgets/Views/CornerWidgetErrorView.swift
+++ b/Shared/Widgets/Views/CornerWidgetErrorView.swift
@@ -13,7 +13,7 @@ struct CornerWidgetErrorView: View {
     var body: some View {
         Button(intent: ReloadWidgetIntent()) {
             Image(systemName: error.image)
-                .font(.title3)
+                .widgetCurvesContent()
                 .fontWeight(.semibold)
                 .invalidatableContent()
                 .widgetLabel(error.description)
@@ -22,3 +22,4 @@ struct CornerWidgetErrorView: View {
         .containerBackground(.background, for: .widget)
     }
 }
+

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -36,18 +36,36 @@ struct CornerWidgetView: View {
 
     private var content: some View {
         Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
-            .font(.title3)
             .fontWeight(.bold)
-            .fontDesign(.rounded)
             .invalidatableContent()
             .foregroundStyle(reading.color(target: targetLower...targetUpper))
+            .widgetCurvesContent()
             .widgetLabel {
-                HStack(spacing: 2) {
-                    if redactionReasons.isEmpty, let image = reading.image {
-                        image
-                    }
-                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false).localizedLowercase)
+                let value = Double(reading.value)
+                let lower = min(value, targetLower)
+                let upper = max(value, targetUpper)
+                Gauge(value: value, in: lower...upper) {
+                    EmptyView()
+                } currentValueLabel: {
+                    Text(reading.value.formatted(.glucose(unit)))
+                } minimumValueLabel: {
+                    Text(Int(lower).formatted(.glucose(unit)))
+                } maximumValueLabel: {
+                    Text(Int(upper).formatted(.glucose(unit)))
                 }
+                .tint(reading.color(target: targetLower...targetUpper))
             }
     }
 }
+
+#if os(watchOS)
+#Preview(as: .accessoryCorner) {
+    ReadingWidget()
+} timeline: {
+    GlucoseEntry<GlucoseReading>(
+        date: .now,
+        widgetURL: nil,
+        state: .reading(.init(value: 55, trend: .fortyFiveDown, date: .now))
+    )
+}
+#endif


### PR DESCRIPTION
## Summary
- Corner widget label now shows a Gauge of the target range with current reading indicated
- If reading is outside target range, bounds extend to include it
- Gauge tinted by reading color

## Test plan
- [ ] Preview accessoryCorner with in-range reading
- [ ] Preview with low reading (55) — lower bound extends
- [ ] Preview with high reading — upper bound extends

🤖 Generated with [Claude Code](https://claude.com/claude-code)