### PR TITLE
Show timestamp at gauge minimum label on corner widget

### DIFF
--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -38,7 +38,7 @@ struct CornerWidgetView: View {
         Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
             .fontWeight(.bold)
             .invalidatableContent()
-            .foregroundStyle(tintColor)
+            .foregroundStyle(reading.color(target: targetLower...targetUpper))
             .widgetCurvesContent()
             .widgetLabel {
                 let value = Double(reading.value)
@@ -47,22 +47,14 @@ struct CornerWidgetView: View {
                 Gauge(value: value, in: lower...upper) {
                     EmptyView()
                 } currentValueLabel: {
-                    Text(reading.value.formatted(.glucose(unit)))
+                    EmptyView()
                 } minimumValueLabel: {
-                    Text(Int(lower).formatted(.glucose(unit)))
+                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false).localizedLowercase)
                 } maximumValueLabel: {
-                    Text(Int(upper).formatted(.glucose(unit)))
+                    EmptyView()
                 }
-                .tint(tintColor)
+                .tint(reading.color(target: targetLower...targetUpper))
             }
-    }
-
-    private var tintColor: Color {
-        switch Double(reading.value) {
-        case ..<targetLower: .red
-        case ...targetUpper: .green
-        default: .yellow
-        }
     }
 }
 

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -47,8 +47,12 @@ struct CornerWidgetView: View {
                 Gauge(value: value, in: lower...upper) {
                     EmptyView()
                 } currentValueLabel: {
+                    EmptyView()
+                } minimumValueLabel: {
                     Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
                         .font(.body.lowercaseSmallCaps())
+                } maximumValueLabel: {
+                    Text(verbatim: "")
                 }
                 .tint(reading.color(target: targetLower...targetUpper))
             }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -52,7 +52,7 @@ struct CornerWidgetView: View {
                     Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
                         .font(.body.lowercaseSmallCaps())
                 } maximumValueLabel: {
-                    EmptyView()
+                    Text(verbatim: "")
                 }
                 .tint(reading.color(target: targetLower...targetUpper))
             }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -49,7 +49,7 @@ struct CornerWidgetView: View {
                 } currentValueLabel: {
                     EmptyView()
                 } minimumValueLabel: {
-                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false).localizedLowercase)
+                    Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
                 } maximumValueLabel: {
                     EmptyView()
                 }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -47,12 +47,8 @@ struct CornerWidgetView: View {
                 Gauge(value: value, in: lower...upper) {
                     EmptyView()
                 } currentValueLabel: {
-                    EmptyView()
-                } minimumValueLabel: {
                     Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
                         .font(.body.lowercaseSmallCaps())
-                } maximumValueLabel: {
-                    Text(verbatim: "")
                 }
                 .tint(reading.color(target: targetLower...targetUpper))
             }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -49,8 +49,7 @@ struct CornerWidgetView: View {
                 } currentValueLabel: {
                     EmptyView()
                 } minimumValueLabel: {
-                    Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
-                        .font(.body.lowercaseSmallCaps())
+                    Text(reading.timestamp(for: entry.date, style: .abbreviated, appendRelativeText: false))
                 } maximumValueLabel: {
                     Text(verbatim: "")
                 }

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -50,6 +50,7 @@ struct CornerWidgetView: View {
                     EmptyView()
                 } minimumValueLabel: {
                     Text(reading.timestamp(for: entry.date, style: .abbreviated).localizedLowercase)
+                        .font(.body.lowercaseSmallCaps())
                 } maximumValueLabel: {
                     EmptyView()
                 }


### PR DESCRIPTION
## Summary
- Reverted corner widget tint to custom app colors (`.lowColor`/`.inRangeColor`/`.highColor`)
- Gauge now shows reading timestamp at `minimumValueLabel`; numeric min/max removed

## Test plan
- [ ] Preview accessoryCorner with recent & older readings
- [ ] Verify gauge colors match rest of app

🤖 Generated with [Claude Code](https://claude.com/claude-code)