### PR TITLE
Drive Live Activity stale level from the server

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -357,12 +357,15 @@ private struct GraphPieceView: View {
 }
 
 private extension ActivityViewContext<ReadingAttributes> {
+    /// Effective stale level. `context.isStale` is the OS-side fallback when no push
+    /// arrives by the activity's staleDate — treat it as offline.
+    var staleLevel: LiveActivityState.StaleLevel {
+        if isStale { return .offline }
+        return state.s ?? .fresh
+    }
+
     var isOffline: Bool {
-        if let reading = state.c {
-            return isStale || reading.isExpired(at: .now, expiration: .init(value: 10, unit: .minutes))
-        } else {
-            return isStale
-        }
+        staleLevel == .offline
     }
 
     var isExpired: Bool {
@@ -370,20 +373,10 @@ private extension ActivityViewContext<ReadingAttributes> {
     }
 
     var timestampColor: Color {
-        if isOffline {
-            return .red
-        }
-
-        if let reading = state.c {
-            if reading.isExpired(at: .now, expiration: .init(value: 10, unit: .minutes)) {
-                return .red
-            } else if reading.isExpired(at: .now, expiration: .init(value: 5, unit: .minutes)) {
-                return .orange
-            } else {
-                return .green
-            }
-        } else {
-            return .red
+        switch staleLevel {
+        case .fresh: .green
+        case .warning: .orange
+        case .stale, .offline: .red
         }
     }
 

--- a/Shared/Intents/StartLiveActivityIntent.swift
+++ b/Shared/Intents/StartLiveActivityIntent.swift
@@ -84,7 +84,7 @@ struct StartLiveActivityIntent: LiveActivityIntent {
             attributes: attributes,
             content: .init(
                 state: initialState,
-                staleDate: Date.now.addingTimeInterval(60 * 10)
+                staleDate: Date.now.addingTimeInterval(60 * 15)
             ),
             pushType: .token
         )

--- a/Shared/Models/LiveActivityState.swift
+++ b/Shared/Models/LiveActivityState.swift
@@ -16,12 +16,21 @@ struct LiveActivityState: Codable, Hashable {
         var v: Int16
     }
 
+    enum StaleLevel: Int, Codable, Hashable {
+        case fresh = 0
+        case warning = 1
+        case stale = 2
+        case offline = 3
+    }
+
     /// current
     var c: GlucoseReading?
     /// history
     var h: [Reading]
     /// sessionExpired
     var se: Bool?
+    /// staleLevel
+    var s: StaleLevel?
 
     /// Creates a LiveActivityState from readings, filtering history to the specified range
     init(readings: [GlucoseReading], range: GraphRange) {
@@ -30,12 +39,14 @@ struct LiveActivityState: Codable, Hashable {
         self.c = filteredReadings.last
         self.h = filteredReadings.toLiveActivityReadings()
         self.se = nil
+        self.s = nil
     }
 
     /// Memberwise initializer for backwards compatibility
-    init(c: GlucoseReading?, h: [Reading], se: Bool? = nil) {
+    init(c: GlucoseReading?, h: [Reading], se: Bool? = nil, s: StaleLevel? = nil) {
         self.c = c
         self.h = h
         self.se = se
+        self.s = s
     }
 }

--- a/Shared/View Models/LiveViewModel.swift
+++ b/Shared/View Models/LiveViewModel.swift
@@ -175,7 +175,7 @@ import KeychainAccess
 
         let content = ActivityContent(
             state: newState,
-            staleDate: Date.now.addingTimeInterval(60 * 10)
+            staleDate: Date.now.addingTimeInterval(60 * 15)
         )
 
         await activity.update(content)


### PR DESCRIPTION
## Summary
- Add `StaleLevel` enum (`fresh`/`warning`/`stale`/`offline`) to `LiveActivityState` so the backend dictates freshness presentation instead of iOS computing thresholds locally.
- Render off `state.s` via a single `staleLevel` computed property; `context.isStale` is treated as `.offline` (the OS staleDate fallback when no push arrives).
- Bump local-push `staleDate` from 10m to 15m to match the new offline threshold; the timestamp still turns red at 10m (via the server's `.stale` push), the "Offline" treatment now triggers at 15m.

Pairs with the matching luka-vapor change that sends `s` in pushes and sets APNS `staleDate = latestReading.date + 15m`.

## Test plan
- [ ] Start a Live Activity, confirm timer shows green
- [ ] At 5m without a new reading, confirm orange via server `.warning` push
- [ ] At 10m, confirm red timer (not "Offline") via server `.stale` push
- [ ] At 15m, confirm "Offline" via server `.offline` push
- [ ] Kill server mid-session; confirm activity flips to "Offline" at the 15m mark via OS staleDate fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)