### PR TITLE
Centralize isLiveActivityRunning logic

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -39,9 +39,7 @@ final class LiveActivityManager {
     }
 
     func syncState() {
-        let hasActivities = !Activity<ReadingAttributes>.activities.isEmpty
-        if Defaults[.isLiveActivityRunning] != hasActivities {
-            Defaults[.isLiveActivityRunning] = hasActivities
+        if ReadingAttributes.syncIsRunningDefault() {
             ControlCenter.shared.reloadAllControls()
         }
     }

--- a/Shared/Intents/ToggleLiveActivityIntent.swift
+++ b/Shared/Intents/ToggleLiveActivityIntent.swift
@@ -5,9 +5,7 @@
 //  Created by Claude on 1/2/26.
 //
 
-import ActivityKit
 import AppIntents
-import Defaults
 
 @available(iOS 18.0, *)
 struct ToggleLiveActivityIntent: SetValueIntent, LiveActivityIntent {
@@ -25,7 +23,9 @@ struct ToggleLiveActivityIntent: SetValueIntent, LiveActivityIntent {
         } else {
             _ = try await EndLiveActivityIntent().perform()
         }
-        Defaults[.isLiveActivityRunning] = !Activity<ReadingAttributes>.activities.isEmpty
+        _ = await MainActor.run {
+            ReadingAttributes.syncIsRunningDefault()
+        }
         return .result()
     }
 }

--- a/Shared/Intents/ToggleLiveActivityIntent.swift
+++ b/Shared/Intents/ToggleLiveActivityIntent.swift
@@ -23,9 +23,8 @@ struct ToggleLiveActivityIntent: SetValueIntent, LiveActivityIntent {
         } else {
             _ = try await EndLiveActivityIntent().perform()
         }
-        _ = await MainActor.run {
-            ReadingAttributes.syncIsRunningDefault()
-        }
+
+        ReadingAttributes.syncIsRunningDefault()
         return .result()
     }
 }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -880,6 +880,9 @@
         }
       }
     },
+    "End Live Activity on server" : {
+
+    },
     "End the currently running Live Activity." : {
       "localizations" : {
         "de" : {
@@ -3607,6 +3610,9 @@
           }
         }
       }
+    },
+    "TestFlight" : {
+
     },
     "This version of Luka is no longer supported. Please update to continue." : {
       "localizations" : {

--- a/Shared/Models/ReadingAttributes.swift
+++ b/Shared/Models/ReadingAttributes.swift
@@ -18,7 +18,6 @@ struct ReadingAttributes: ActivityAttributes {
 
 extension ReadingAttributes {
     /// Returns true if there is at least one Live Activity that has not yet ended or been dismissed.
-    @MainActor
     static var hasRunningActivity: Bool {
         Activity<ReadingAttributes>.activities.contains { activity in
             switch activity.activityState {
@@ -34,7 +33,6 @@ extension ReadingAttributes {
 
     /// Updates `Defaults[.isLiveActivityRunning]` to reflect the current Live Activity state.
     /// Returns true if the stored value changed.
-    @MainActor
     @discardableResult
     static func syncIsRunningDefault() -> Bool {
         let isRunning = hasRunningActivity

--- a/Shared/Models/ReadingAttributes.swift
+++ b/Shared/Models/ReadingAttributes.swift
@@ -6,6 +6,7 @@
 //
 
 import ActivityKit
+import Defaults
 import Foundation
 import Dexcom
 
@@ -13,4 +14,32 @@ struct ReadingAttributes: ActivityAttributes {
     typealias ContentState = LiveActivityState
 
     var range: GraphRange
+}
+
+extension ReadingAttributes {
+    /// Returns true if there is at least one Live Activity that has not yet ended or been dismissed.
+    @MainActor
+    static var hasRunningActivity: Bool {
+        Activity<ReadingAttributes>.activities.contains { activity in
+            switch activity.activityState {
+            case .active, .pending, .stale:
+                return true
+            case .dismissed, .ended:
+                return false
+            @unknown default:
+                return false
+            }
+        }
+    }
+
+    /// Updates `Defaults[.isLiveActivityRunning]` to reflect the current Live Activity state.
+    /// Returns true if the stored value changed.
+    @MainActor
+    @discardableResult
+    static func syncIsRunningDefault() -> Bool {
+        let isRunning = hasRunningActivity
+        guard Defaults[.isLiveActivityRunning] != isRunning else { return false }
+        Defaults[.isLiveActivityRunning] = isRunning
+        return true
+    }
 }

--- a/Shared/Widgets/LiveActivityControl.swift
+++ b/Shared/Widgets/LiveActivityControl.swift
@@ -5,7 +5,7 @@
 //  Created by Claude on 1/2/26.
 //
 
-import ActivityKit
+import Defaults
 import SwiftUI
 import WidgetKit
 
@@ -35,7 +35,7 @@ extension LiveActivityControl {
         var previewValue: Bool { false }
 
         func currentValue() async throws -> Bool {
-            !Activity<ReadingAttributes>.activities.isEmpty
+            Defaults[.isLiveActivityRunning]
         }
     }
 }


### PR DESCRIPTION
## Summary
- Filter out `.ended`/`.dismissed` activities when computing `isLiveActivityRunning`
- Centralize the logic in `ReadingAttributes.hasRunningActivity` / `syncIsRunningDefault()`
- `LiveActivityControl` now reads from the shared default (querying `Activity.activities` from a Control doesn't work)

## Test plan
- [ ] Start a Live Activity, confirm the Control reflects the running state
- [ ] End the Live Activity, confirm the Control turns off
- [ ] Toggle via the Control widget, confirm state stays in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)