### PR TITLE
Add Sugarmate and Omnipod as widget launch targets, bump to 2.6.0

### DIFF
--- a/Luka.xcodeproj/project.pbxproj
+++ b/Luka.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.GlimpseWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -744,7 +744,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -772,7 +772,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp;
 				PRODUCT_NAME = Luka;
 				SDKROOT = watchos;
@@ -801,7 +801,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -830,7 +830,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse.watchkitapp.WatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1038,7 +1038,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1070,7 +1070,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kylebashour.Glimpse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Shared/Intents/LaunchableApp.swift
+++ b/Shared/Intents/LaunchableApp.swift
@@ -18,6 +18,8 @@ enum LaunchableApp: String, AppEnum {
             .g7: "Dexcom G7",
             .g6: "Dexcom G6",
             .clarity: "Dexcom Clarity",
+            .sugarmate: "Sugarmate",
+            .omnipod: "Omnipod",
         ]
     }
 
@@ -31,6 +33,10 @@ enum LaunchableApp: String, AppEnum {
             "dexcomg6://"
         case .clarity:
             "claritymobile://"
+        case .sugarmate:
+            "sugarmate://"
+        case .omnipod:
+            "omnipod://"
         }
 
         return URL(string: string)!
@@ -40,4 +46,6 @@ enum LaunchableApp: String, AppEnum {
     case g7
     case g6
     case clarity
+    case sugarmate
+    case omnipod
 }


### PR DESCRIPTION
## Summary
- Add Sugarmate (`sugarmate://`) and Omnipod (`omnipod://`) as `LaunchableApp` cases — they now show up in the Reading and Graph widget configuration pickers.
- Bump MARKETING_VERSION from 2.5.2 to 2.6.0.

## Test plan
- [ ] Configure a Reading widget, select Sugarmate as launch target, tap the widget → opens Sugarmate
- [ ] Configure a Graph widget, select Omnipod as launch target, tap the widget → opens Omnipod
- [ ] Verify existing Luka/Dexcom G7/G6/Clarity options still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)