### PR TITLE
Show session/token/push dates in Live Activity debug grid

### DIFF
--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -23,6 +23,7 @@ struct SettingsView: View {
     @Default(.unit) private var unit
     @Default(.sessionHistory) private var sessionHistory
     @Default(.useReadingsProxy) private var useReadingsProxy
+    @Default(.debugInfo) private var debugInfo
 
     private var username: String? {
         Keychain.shared.username
@@ -75,6 +76,9 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.menu)
                 }
+
+                Toggle("Debug info", isOn: $debugInfo)
+                    .tint(.accent)
             }
 
             Section {

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -450,12 +450,16 @@ private struct DebugInfoGrid: View {
     var body: some View {
         Grid(alignment: .leading, horizontalSpacing: .spacing6, verticalSpacing: .spacing3) {
             GridRow {
-                LabeledDate(label: "Session", date: context.state.sd)
-                LabeledDate(label: "Token", date: context.state.td)
+                LabeledValue(label: "Session", value: context.state.sd?.formatted())
+                LabeledValue(label: "Token", value: context.state.td?.formatted())
             }
             GridRow {
-                LabeledDate(label: "Push", date: context.state.pd)
-                LabeledDate(label: "Now", date: .now)
+                LabeledValue(label: "Push", value: context.state.pd?.formatted())
+                LabeledValue(label: "Now", value: Date.now.formatted())
+            }
+            GridRow {
+                LabeledValue(label: "Tokens", value: context.state.tc.map { "\($0)" })
+                Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
             }
         }
         .font(.footnote.bold())
@@ -464,20 +468,16 @@ private struct DebugInfoGrid: View {
     }
 }
 
-private struct LabeledDate: View {
+private struct LabeledValue: View {
     var label: LocalizedStringKey
-    var date: Date?
+    var value: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(label)
                 .textCase(.uppercase)
                 .foregroundStyle(.tertiary)
-            if let date {
-                Text(date.formatted())
-            } else {
-                Text(verbatim: "—")
-            }
+            Text(verbatim: value ?? "—")
         }
         .lineLimit(1)
         .minimumScaleFactor(0.6)

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -177,6 +177,7 @@ private struct MainContentView: View {
 
     @Environment(\.activityFamily) private var family
     @Default(.showChartLiveActivity) private var _showChartLiveActivity
+    @Default(.debugInfo) private var debugInfo
 
     var showChartLiveActivity: Bool {
         _showChartLiveActivity && !context.isOffline
@@ -243,12 +244,18 @@ private struct MainContentView: View {
                     .contentTransition(.numericText())
                 }
                 .padding([.horizontal, .top])
-                .padding(showChartLiveActivity ? [] : .bottom)
+                .padding((showChartLiveActivity || debugInfo) ? [] : .bottom)
 
                 if showChartLiveActivity {
                     GraphPieceView(context: context)
                         .padding(.top, 10)
-                        .padding(.bottom)
+                        .padding(debugInfo ? [] : .bottom)
+                }
+
+                if debugInfo {
+                    DebugInfoGrid(context: context)
+                        .padding(.top, 10)
+                        .padding([.horizontal, .bottom])
                 }
             }
         }
@@ -434,6 +441,47 @@ private struct MinuteTimerView: View {
             }
         }
         .foregroundStyle(context.timestampColor)
+    }
+}
+
+private struct DebugInfoGrid: View {
+    var context: ActivityViewContext<ReadingAttributes>
+
+    var body: some View {
+        Grid(alignment: .leading, horizontalSpacing: .spacing6, verticalSpacing: .spacing3) {
+            GridRow {
+                LabeledDate(label: "Session", date: context.state.sd)
+                LabeledDate(label: "Token", date: context.state.td)
+            }
+            GridRow {
+                LabeledDate(label: "Push", date: context.state.pd)
+                LabeledDate(label: "Now", date: .now)
+            }
+        }
+        .font(.footnote.bold())
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct LabeledDate: View {
+    var label: LocalizedStringKey
+    var date: Date?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(label)
+                .textCase(.uppercase)
+                .foregroundStyle(.tertiary)
+            if let date {
+                Text(date.formatted())
+            } else {
+                Text(verbatim: "—")
+            }
+        }
+        .lineLimit(1)
+        .minimumScaleFactor(0.6)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Shared/Models/LiveActivityState.swift
+++ b/Shared/Models/LiveActivityState.swift
@@ -31,6 +31,14 @@ struct LiveActivityState: Codable, Hashable {
     var se: Bool?
     /// staleLevel
     var s: StaleLevel?
+    /// sessionStartDate — when the live activity session first started
+    var sd: Date?
+    /// tokenStartDate — when this push token was added to the session
+    var td: Date?
+    /// tokenCount — number of tokens currently receiving pushes for this session
+    var tc: Int?
+    /// pushDate — when this push was sent
+    var pd: Date?
 
     /// Creates a LiveActivityState from readings, filtering history to the specified range
     init(readings: [GlucoseReading], range: GraphRange) {
@@ -43,10 +51,23 @@ struct LiveActivityState: Codable, Hashable {
     }
 
     /// Memberwise initializer for backwards compatibility
-    init(c: GlucoseReading?, h: [Reading], se: Bool? = nil, s: StaleLevel? = nil) {
+    init(
+        c: GlucoseReading?,
+        h: [Reading],
+        se: Bool? = nil,
+        s: StaleLevel? = nil,
+        sd: Date? = nil,
+        td: Date? = nil,
+        tc: Int? = nil,
+        pd: Date? = nil
+    ) {
         self.c = c
         self.h = h
         self.se = se
         self.s = s
+        self.sd = sd
+        self.td = td
+        self.tc = tc
+        self.pd = pd
     }
 }

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -37,6 +37,7 @@ extension Defaults.Keys {
     static let isLiveActivityRunning = Key<Bool>("isLiveActivityRunning", default: false, suite: .shared)
     static let cachedReadings = Key<GlucoseReadingsCache?>("cachedReadings", default: nil, suite: .shared)
     static let useReadingsProxy = Key<Bool>("useReadingsProxy", default: false, suite: .shared, iCloud: true)
+    static let debugInfo = Key<Bool>("debugInfo", default: false, suite: .shared)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
Adopts the new sessionStartDate/tokenStartDate/tokenCount/pushDate fields
from the Vapor backend, gated behind a "Debug info" toggle in Settings.
When enabled, the medium Live Activity surfaces a 2x2 grid of those dates
plus the current local date at the bottom of the view.