### PR TITLE
Add keyline-tinted border to small Live Activity view

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -176,6 +176,8 @@ private struct MainContentView: View {
     var context: ActivityViewContext<ReadingAttributes>
 
     @Environment(\.activityFamily) private var family
+    @Default(.targetRangeLowerBound) private var targetLower
+    @Default(.targetRangeUpperBound) private var targetUpper
     @Default(.showChartLiveActivity) private var _showChartLiveActivity
     @Default(.debugInfo) private var debugInfo
 
@@ -211,6 +213,13 @@ private struct MainContentView: View {
                     .layoutPriority(10)
             }
             .padding(10)
+            .overlay {
+                ContainerRelativeShape()
+                    .strokeBorder(
+                        context.state.c?.color(target: targetLower...targetUpper) ?? .clear,
+                        lineWidth: 2
+                    )
+            }
         }
     }
 

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -217,7 +217,7 @@ private struct MainContentView: View {
                 ContainerRelativeShape()
                     .strokeBorder(
                         context.state.c?.color(target: targetLower...targetUpper) ?? .clear,
-                        lineWidth: 2
+                        lineWidth: 1
                     )
             }
         }


### PR DESCRIPTION
Strokes a ContainerRelativeShape around the watchOS small activity
view using the same color as the keyline tint so the container reads
as glucose-status-colored at a glance in the Smart Stack.