### PR TITLE
Add border to small watchOS Live Activity view

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -216,8 +216,8 @@ private struct MainContentView: View {
             .overlay {
                 ContainerRelativeShape()
                     .strokeBorder(
-                        context.state.c?.color(target: targetLower...targetUpper) ?? .clear,
-                        lineWidth: 1
+                        (context.state.c?.color(target: targetLower...targetUpper) ?? .clear).opacity(0.5),
+                        lineWidth: 2
                     )
             }
         }


### PR DESCRIPTION
## Summary
- Stroke a `ContainerRelativeShape` around the watchOS small Live Activity view using the same glucose-status color as the existing `.keylineTint`
- Border is 2pt at 0.5 opacity

## Test plan
- [ ] Inspect the small activity in the watchOS Smart Stack across low / in-range / high glucose states
- [ ] Confirm the stroke sits flush with the container edge and matches the keyline tint color
- [ ] Verify the border is hidden / harmless when there's no current reading (color falls back to clear)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkvKVM3tJPMaZqbio4xpxA)_