### PR TITLE
Add Experimental settings view with end-all-live-activities action

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -133,12 +133,9 @@ final class LiveActivityManager {
 
         let payload = EndLiveActivitiesRequest(username: username)
 
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .useDefaultKeys
-
         var request = URLRequest(url: Backend.current.url(for: "end-live-activities"))
         request.httpMethod = "POST"
-        request.httpBody = try! encoder.encode(payload)
+        request.httpBody = try! JSONEncoder().encode(payload)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         await withBackgroundTask(name: "LiveActivity.sendEndAllLiveActivities") {

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -128,6 +128,29 @@ final class LiveActivityManager {
         }
     }
 
+    func endAllLiveActivitiesOnServer() async {
+        guard let username = Keychain.shared.username else { return }
+
+        let payload = EndLiveActivitiesRequest(username: username)
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .useDefaultKeys
+
+        var request = URLRequest(url: Backend.current.url(for: "end-live-activities"))
+        request.httpMethod = "POST"
+        request.httpBody = try! encoder.encode(payload)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        await withBackgroundTask(name: "LiveActivity.sendEndAllLiveActivities") {
+            do {
+                _ = try await URLSession.shared.data(for: request)
+                TelemetryDeck.signal("LiveActivity.sentEndAll")
+            } catch {
+                TelemetryDeck.signal("LiveActivity.failedToSendEndAll")
+            }
+        }
+    }
+
     private func sendEndLiveActivity(activityID: String) async {
         guard let username = Keychain.shared.username,
               let pushToken = activityTokens[activityID] else { return }

--- a/Luka/Views/ExperimentalView.swift
+++ b/Luka/Views/ExperimentalView.swift
@@ -1,0 +1,50 @@
+//
+//  ExperimentalView.swift
+//  Luka
+//
+//  Created by Claude on 5/25/26.
+//
+
+import SwiftUI
+import Defaults
+
+struct ExperimentalView: View {
+    @Default(.debugInfo) private var debugInfo
+
+    var body: some View {
+        List {
+            Section("Live Activities") {
+                Toggle("Debug info", isOn: $debugInfo)
+                    .tint(.accent)
+            }
+
+            Section {
+                Button {
+                    Task {
+                        await LiveActivityManager.shared.endLiveActivityOnServer()
+                    }
+                } label: {
+                    SettingsRow("End Live Activity on server", systemImage: "antenna.radiowaves.left.and.right.slash")
+                }
+
+                Button {
+                    Task {
+                        await LiveActivityManager.shared.endAllLiveActivitiesOnServer()
+                    }
+                } label: {
+                    SettingsRow("End all Live Activities", systemImage: "xmark.circle")
+                }
+            }
+            .fontWeight(.medium)
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Experimental")
+        .fontDesign(.rounded)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ExperimentalView()
+    }
+}

--- a/Luka/Views/SettingsRow.swift
+++ b/Luka/Views/SettingsRow.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsRow.swift
+//  Luka
+//
+//  Created by Claude on 5/25/26.
+//
+
+import SwiftUI
+
+struct SettingsRow: View {
+    @ScaledMetric private var iconFrameWidth: CGFloat = 24
+
+    var title: LocalizedStringKey
+    var systemImage: String
+
+    init(_ title: LocalizedStringKey, systemImage: String) {
+        self.title = title
+        self.systemImage = systemImage
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Image(systemName: systemImage)
+                .frame(width: iconFrameWidth, alignment: .center)
+        }
+    }
+}

--- a/Luka/Views/SettingsView.swift
+++ b/Luka/Views/SettingsView.swift
@@ -23,7 +23,6 @@ struct SettingsView: View {
     @Default(.unit) private var unit
     @Default(.sessionHistory) private var sessionHistory
     @Default(.useReadingsProxy) private var useReadingsProxy
-    @Default(.debugInfo) private var debugInfo
 
     private var username: String? {
         Keychain.shared.username
@@ -76,9 +75,6 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.menu)
                 }
-
-                Toggle("Debug info", isOn: $debugInfo)
-                    .tint(.accent)
             }
 
             Section {
@@ -107,18 +103,14 @@ struct SettingsView: View {
             }
             .fontWeight(.medium)
 
-            if Bundle.main.isSandboxReceipt {
-                Section("TestFlight") {
-                    Button {
-                        Task {
-                            await LiveActivityManager.shared.endLiveActivityOnServer()
-                        }
-                    } label: {
-                        SettingsRow("End Live Activity on server", systemImage: "antenna.radiowaves.left.and.right.slash")
-                    }
+            Section {
+                NavigationLink {
+                    ExperimentalView()
+                } label: {
+                    SettingsRow("Experimental", systemImage: "flask")
                 }
-                .fontWeight(.medium)
             }
+            .fontWeight(.medium)
 
             Section {
                 Button {
@@ -159,27 +151,6 @@ struct SettingsView: View {
             }
         }
         .fontDesign(.rounded)
-    }
-}
-
-private struct SettingsRow: View {
-    @ScaledMetric private var iconFrameWidth: CGFloat = 24
-
-    var title: LocalizedStringKey
-    var systemImage: String
-
-    init(_ title: LocalizedStringKey, systemImage: String) {
-        self.title = title
-        self.systemImage = systemImage
-    }
-
-    var body: some View {
-        HStack {
-            Text(title)
-            Spacer()
-            Image(systemName: systemImage)
-                .frame(width: iconFrameWidth, alignment: .center)
-        }
     }
 }
 

--- a/Shared/Models/EndLiveActivityRequest.swift
+++ b/Shared/Models/EndLiveActivityRequest.swift
@@ -12,3 +12,7 @@ struct EndLiveActivityRequest: Codable {
     var pushToken: String
     var username: String
 }
+
+struct EndLiveActivitiesRequest: Codable {
+    var username: String
+}


### PR DESCRIPTION
Adds a new ExperimentalView accessed from a button in Settings, housing the
Live Activity debug toggle, the existing end-Live-Activity-on-server action,
and a new button that hits the /end-live-activities endpoint added in the
latest Luka-vapor commit to clear all server-side sessions for the user.