### PR TITLE
Replace small activity view border with gradient background

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -213,11 +213,12 @@ private struct MainContentView: View {
                     .layoutPriority(10)
             }
             .padding(10)
-            .containerBackground(for: .widget) {
+            .containerBackground(
                 (context.state.c?.color(target: targetLower...targetUpper) ?? .clear)
                     .opacity(0.3)
-                    .gradient
-            }
+                    .gradient,
+                for: .widget
+            )
         }
     }
 

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -213,12 +213,10 @@ private struct MainContentView: View {
                     .layoutPriority(10)
             }
             .padding(10)
-            .overlay {
-                ContainerRelativeShape()
-                    .strokeBorder(
-                        (context.state.c?.color(target: targetLower...targetUpper) ?? .clear).opacity(0.5),
-                        lineWidth: 2
-                    )
+            .containerBackground(for: .widget) {
+                (context.state.c?.color(target: targetLower...targetUpper) ?? .clear)
+                    .opacity(0.3)
+                    .gradient
             }
         }
     }


### PR DESCRIPTION
Use the glucose color at 0.3 opacity as a container background gradient
instead of a stroked border for a softer, fuller-bleed look.