### PR TITLE
Mark session expired on Live Activity end event

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -54,6 +54,9 @@ final class LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
+                    var endState = activity.content.state
+                    endState.se = true
+                    await activity.update(ActivityContent(state: endState, staleDate: nil))
                     await sendEndLiveActivity(activityID: activity.id)
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)


### PR DESCRIPTION
Set se = true on the activity content state when a .dismissed or
.ended state update is received, before signaling the server.