### PR TITLE
Fix data race warning when ending Live Activity

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -54,12 +54,13 @@ final class LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
+                    let activityID = activity.id
                     var endState = activity.content.state
                     endState.se = true
                     await activity.update(ActivityContent(state: endState, staleDate: nil))
-                    await sendEndLiveActivity(activityID: activity.id)
-                    observationTasks.removeValue(forKey: activity.id)
-                    activityTokens.removeValue(forKey: activity.id)
+                    await sendEndLiveActivity(activityID: activityID)
+                    observationTasks.removeValue(forKey: activityID)
+                    activityTokens.removeValue(forKey: activityID)
                     syncState()
                     return
                 case .active, .pending, .stale:


### PR DESCRIPTION
Capture activity.id into a local before calling activity.update so the
activity value isn't accessed again on the main actor after being sent
into the nonisolated async update call.