### PR TITLE
Revert Live Activity session-expired-on-end changes

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -54,9 +54,6 @@ final class LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
-                    var endState = activity.content.state
-                    endState.se = true
-                    await activity.update(ActivityContent(state: endState, staleDate: nil))
                     await sendEndLiveActivity(activityID: activity.id)
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)

--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -54,13 +54,12 @@ final class LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
-                    let activityID = activity.id
                     var endState = activity.content.state
                     endState.se = true
                     await activity.update(ActivityContent(state: endState, staleDate: nil))
-                    await sendEndLiveActivity(activityID: activityID)
-                    observationTasks.removeValue(forKey: activityID)
-                    activityTokens.removeValue(forKey: activityID)
+                    await sendEndLiveActivity(activityID: activity.id)
+                    observationTasks.removeValue(forKey: activity.id)
+                    activityTokens.removeValue(forKey: activity.id)
                     syncState()
                     return
                 case .active, .pending, .stale:


### PR DESCRIPTION
Reverts the two recently merged changes to `LiveActivityManager`:

- #90 "Mark session expired on Live Activity end event" — set `se = true` on the content state and called `activity.update(_:)` when a `.dismissed`/`.ended` state update arrived.
- #91 "Fix data race warning when ending Live Activity" — the follow-up attempt to silence the `Sending 'activity' risks causing data races` diagnostic.

This restores `observeActivity(_:)` to its original behavior: on a terminal state it simply calls `sendEndLiveActivity` and cleans up, with no `activity.update(_:)` call.

https://claude.ai/code/session_01Y93nm5suoZSzciB5iHHRif

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y93nm5suoZSzciB5iHHRif)_