### PR TITLE
Send activity ID to start/end live activity API calls

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -72,7 +72,7 @@ final class LiveActivityManager {
                 let kind: String = activityTokens[activity.id] == nil ? "initial" : "update"
                 activityTokens[activity.id] = tokenString
                 TelemetryDeck.signal("LiveActivity.receivedToken", parameters: ["kind": kind])
-                await sendStartLiveActivity(token: tokenString, kind: kind)
+                await sendStartLiveActivity(activityID: activity.id, token: tokenString, kind: kind)
             }
         }
 
@@ -83,7 +83,7 @@ final class LiveActivityManager {
         }
     }
 
-    private func sendStartLiveActivity(token: String, kind: String) async {
+    private func sendStartLiveActivity(activityID: String, token: String, kind: String) async {
         guard let username = Keychain.shared.username,
               let password = Keychain.shared.password,
               let accountLocation = Defaults[.accountLocation],
@@ -93,6 +93,7 @@ final class LiveActivityManager {
 
         let range: GraphRange = .threeHours
         let payload = StartLiveActivityRequest(
+            activityID: activityID,
             pushToken: token,
             environment: .current,
             username: username,
@@ -143,7 +144,7 @@ final class LiveActivityManager {
         guard let username = Keychain.shared.username,
               let pushToken = activityTokens[activityID] else { return }
 
-        let payload = EndLiveActivityRequest(pushToken: pushToken, username: username)
+        let payload = EndLiveActivityRequest(pushToken: pushToken, username: username, activityID: activityID)
 
         await client.withBackgroundTask(name: "LiveActivity.sendEndLiveActivity") {
             do {

--- a/Shared/Models/EndLiveActivityRequest.swift
+++ b/Shared/Models/EndLiveActivityRequest.swift
@@ -11,6 +11,7 @@ import Foundation
 struct EndLiveActivityRequest: Codable {
     var pushToken: String
     var username: String
+    var activityID: String?
 }
 
 struct EndLiveActivitiesRequest: Codable {

--- a/Shared/Models/StartLiveActivityRequest.swift
+++ b/Shared/Models/StartLiveActivityRequest.swift
@@ -29,6 +29,7 @@ struct LiveActivityPreferences: Codable {
 }
 
 struct StartLiveActivityRequest: Codable {
+    var activityID: String?
     var pushToken: String
     var environment: PushEnvironment
     var username: String?


### PR DESCRIPTION
The backend (luka-vapor#44) now accepts an optional activityID on the
start-live-activity and end-live-activity endpoints to use as a stable
identifier across push token rotations. Thread the ActivityKit activity
id through to both requests.