### PR TITLE
Add HDR exposure glow to glucose colors on iOS/watchOS 26

### DIFF
--- a/Shared/Utilities/Color+Extensions.swift
+++ b/Shared/Utilities/Color+Extensions.swift
@@ -8,22 +8,32 @@
 import SwiftUI
 
 extension Color {
+    // On iOS/watchOS 26+ the colors are nudged into HDR headroom via
+    // `exposureAdjust` so out-of-range readings glow on capable displays.
+    // In-range gets a much gentler lift so it stays calm; everything falls
+    // back to the plain SDR color on older OSes and non-HDR displays.
     static var lowColor: Color {
-        if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 26, *) {
+            Color.pink.mix(with: .red, by: 0.7).exposureAdjust(0.5)
+        } else if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.pink.mix(with: .red, by: 0.7)
         } else {
             Color.red
         }
     }
     static var inRangeColor: Color {
-        if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 26, *) {
+            Color.green.mix(with: .mint, by: 0.25).exposureAdjust(0.2)
+        } else if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.green.mix(with: .mint, by: 0.25)
         } else {
             Color.green
         }
     }
     static var highColor: Color {
-        if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 26, *) {
+            Color.yellow.mix(with: .orange, by: 0.65).exposureAdjust(0.5)
+        } else if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.yellow.mix(with: .orange, by: 0.65)
         } else {
             Color.orange


### PR DESCRIPTION
Builds on the punchier color palette from #96 by using the new iOS 26 `Color.exposureAdjust(_:)` API to nudge the shared glucose colors into HDR headroom, so readings pop on capable displays.

## What changed

All three colors get an HDR lift, with out-of-range emphasized and in-range kept calm:

- **Low / High:** `+0.5` stop — out-of-range readings glow
- **In-range:** `+0.2` stop — gentle, stays calm

Because `exposureAdjust` returns a `Color`, the change is baked into the single source of truth (`Color+Extensions.swift`), so it flows automatically to the chart dots, the line/range gradients, the big reading number, and the Watch — no per-view changes.

## Safety / fallback

- Gated to iOS/watchOS **26** specifically (`exposureAdjust` requires watchOS 26, whereas the existing `.mix` path only needs watchOS 11), so a separate branch was added — watchOS 11–25 keeps the SDR mix, older OSes keep flat red/green/orange.
- On non-HDR displays the effect falls back to the normal SDR color, so there's no downside on older hardware.

## Testing notes

⚠️ Not yet verified on-device. HDR colors don't render in the Simulator, so this needs a build on a **real HDR device** (iPhone 12 Pro+ / recent Apple Watch) to see the glow and tune the stops. The `+0.5` / `+0.2` stop values are easy knobs in `Color+Extensions.swift` if the glow feels too strong or weak.

https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ)_