### PR TITLE
Limit HDR glow to compact Live Activity readings

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -113,6 +113,21 @@ private struct ReadingArrow: View {
     }
 }
 
+/// The compact Live Activity tint, nudged into HDR headroom on iOS 26 so the
+/// reading glows in the Dynamic Island. Falls back to the SDR gradient on older
+/// OSes and non-HDR displays, and to `.secondary` when there's no reading.
+private func compactReadingTint(_ reading: GlucoseReading?, target: ClosedRange<Double>) -> AnyShapeStyle {
+    guard let reading else {
+        return AnyShapeStyle(Color.secondary.gradient)
+    }
+    let color = reading.color(target: target)
+    if #available(iOS 26, *) {
+        return AnyShapeStyle(color.exposureAdjust(0.5).gradient)
+    } else {
+        return AnyShapeStyle(color.gradient)
+    }
+}
+
 private struct CompactReadingText: View {
     var context: ActivityViewContext<ReadingAttributes>
 
@@ -124,7 +139,7 @@ private struct CompactReadingText: View {
         WithRange {
             ReadingText(context: context)
                 .fontWeight(.bold)
-                .foregroundStyle((reading?.color(target: $0) ?? .secondary).gradient)
+                .foregroundStyle(compactReadingTint(reading, target: $0))
                 .opacity(context.isOffline ? 0.5 : 1)
         }
     }
@@ -148,7 +163,7 @@ private struct CompactReadingArrow: View {
                 }
             }
             .fontWeight(.bold)
-            .foregroundStyle((reading?.color(target: $0) ?? .secondary).gradient)
+            .foregroundStyle(compactReadingTint(reading, target: $0))
         }
     }
 }

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -113,10 +113,11 @@ private struct ReadingArrow: View {
     }
 }
 
-/// The compact Live Activity tint, nudged into HDR headroom on iOS 26 so the
-/// reading glows in the Dynamic Island. Falls back to the SDR gradient on older
-/// OSes and non-HDR displays, and to `.secondary` when there's no reading.
-private func compactReadingTint(_ reading: GlucoseReading?, target: ClosedRange<Double>) -> AnyShapeStyle {
+/// The compact/minimal Live Activity tint, nudged into HDR headroom on iOS 26
+/// so the reading glows in the Dynamic Island. Falls back to the SDR gradient
+/// on older OSes and non-HDR displays, and to `.secondary` when there's no
+/// reading.
+private func liveActivityReadingTint(_ reading: GlucoseReading?, target: ClosedRange<Double>) -> AnyShapeStyle {
     guard let reading else {
         return AnyShapeStyle(Color.secondary.gradient)
     }
@@ -139,7 +140,7 @@ private struct CompactReadingText: View {
         WithRange {
             ReadingText(context: context)
                 .fontWeight(.bold)
-                .foregroundStyle(compactReadingTint(reading, target: $0))
+                .foregroundStyle(liveActivityReadingTint(reading, target: $0))
                 .opacity(context.isOffline ? 0.5 : 1)
         }
     }
@@ -163,7 +164,7 @@ private struct CompactReadingArrow: View {
                 }
             }
             .fontWeight(.bold)
-            .foregroundStyle(compactReadingTint(reading, target: $0))
+            .foregroundStyle(liveActivityReadingTint(reading, target: $0))
         }
     }
 }
@@ -184,7 +185,7 @@ private struct MinimalReadingView: View {
                     .fontWeight(.bold)
                     .fontWidth(.compressed)
                     .redacted(reason: context.isOffline ? .placeholder : [])
-                    .foregroundStyle((reading?.color(target: $0) ?? .secondary).gradient)
+                    .foregroundStyle(liveActivityReadingTint(reading, target: $0))
             }
         }
     }

--- a/Shared/Utilities/Color+Extensions.swift
+++ b/Shared/Utilities/Color+Extensions.swift
@@ -8,32 +8,22 @@
 import SwiftUI
 
 extension Color {
-    // On iOS/watchOS 26+ the colors are nudged into HDR headroom via
-    // `exposureAdjust` so out-of-range readings glow on capable displays.
-    // In-range gets a much gentler lift so it stays calm; everything falls
-    // back to the plain SDR color on older OSes and non-HDR displays.
     static var lowColor: Color {
-        if #available(iOS 26, *), #available(watchOS 26, *) {
-            Color.pink.mix(with: .red, by: 0.7).exposureAdjust(0.5)
-        } else if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.pink.mix(with: .red, by: 0.7)
         } else {
             Color.red
         }
     }
     static var inRangeColor: Color {
-        if #available(iOS 26, *), #available(watchOS 26, *) {
-            Color.green.mix(with: .mint, by: 0.25).exposureAdjust(0.2)
-        } else if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.green.mix(with: .mint, by: 0.25)
         } else {
             Color.green
         }
     }
     static var highColor: Color {
-        if #available(iOS 26, *), #available(watchOS 26, *) {
-            Color.yellow.mix(with: .orange, by: 0.65).exposureAdjust(0.5)
-        } else if #available(iOS 26, *), #available(watchOS 11, *) {
+        if #available(iOS 26, *), #available(watchOS 11, *) {
             Color.yellow.mix(with: .orange, by: 0.65)
         } else {
             Color.orange


### PR DESCRIPTION
Follow-up to the HDR work (#97). The broad HDR exposure looked bad everywhere except the tinted readings in the compact Live Activity, so this scopes it down to just that.

## What changed

- **Revert the shared colors:** `Color+Extensions.swift` goes back to the punchy SDR mix (no `exposureAdjust`), restoring normal rendering across the chart, widgets, big reading number, and Watch.
- **HDR only in the compact Dynamic Island:** the compact reading value (`CompactReadingText`) and arrow (`CompactReadingArrow`) now use a fixed `+0.5` stop `exposureAdjust`, via a small `compactReadingTint` helper.

The helper falls back to the plain SDR gradient on pre-iOS 26 and non-HDR displays, and to `.secondary` when there's no reading — same behavior as before, just with the HDR lift layered in where supported.

## Testing notes

⚠️ Not verified on-device — HDR doesn't render in the Simulator. Needs a build on a real HDR iPhone to confirm the compact Dynamic Island glow looks right.

https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ)_