### PR TITLE
Tone down Live Activity HDR glow to +0.25 stop

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -123,7 +123,7 @@ private func liveActivityReadingTint(_ reading: GlucoseReading?, target: ClosedR
     }
     let color = reading.color(target: target)
     if #available(iOS 26, *) {
-        return AnyShapeStyle(color.exposureAdjust(0.5).gradient)
+        return AnyShapeStyle(color.exposureAdjust(0.25).gradient)
     } else {
         return AnyShapeStyle(color.gradient)
     }


### PR DESCRIPTION
Tones the Dynamic Island HDR glow down from `+0.5` to `+0.25` stop for a subtler effect. One-line change in `liveActivityReadingTint`.

⚠️ Not verified on-device — HDR doesn't render in the Simulator.

https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015eLVHovk5biXhUtPCfbWtJ)_