### PR TITLE
Enable Live Activity tap to launch watch app

### DIFF
--- a/Watch/Info.plist
+++ b/Watch/Info.plist
@@ -3,6 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>WKSupportsLiveActivityLaunchAttributeTypes</key>
-	<array/>
+	<array>
+		<string>ReadingAttributes</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The watch app's Info.plist declared an empty
WKSupportsLiveActivityLaunchAttributeTypes array, so watchOS did not
launch the app when its Live Activity (rendered via the .small
supplemental activity family) was tapped. List ReadingAttributes so taps
open the watch app.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015DE1P12EcRZSK33cnGrX7F