### PR TITLE
Make watch widgets configurable on watchOS 26

### DIFF
--- a/Shared/Widgets/GraphTimelineProvider.swift
+++ b/Shared/Widgets/GraphTimelineProvider.swift
@@ -40,7 +40,14 @@ struct GraphTimelineProvider: AppIntentTimelineProvider, DexcomTimelineProvider 
     }
 
     func recommendations() -> [AppIntentRecommendation<GraphWidgetConfiguration>] {
-        GraphRange.allCases.map {
+        #if os(watchOS)
+        // watchOS 26 and later provide an interface for configuring widgets and
+        // complications, so return an empty array to let people configure them.
+        if #available(watchOS 26.0, *) {
+            return []
+        }
+        #endif
+        return GraphRange.allCases.map {
             let configuration = GraphWidgetConfiguration(graphRange: $0)
             return AppIntentRecommendation(intent: configuration, description: $0.abbreviatedName + " Graph")
         }

--- a/Shared/Widgets/ReadingTimelineProvider.swift
+++ b/Shared/Widgets/ReadingTimelineProvider.swift
@@ -29,7 +29,14 @@ struct ReadingTimelineProvider: AppIntentTimelineProvider, DexcomTimelineProvide
     }
 
     func recommendations() -> [AppIntentRecommendation<ReadingWidgetConfiguration>] {
-        [AppIntentRecommendation(intent: ReadingWidgetConfiguration(), description: "Current Reading")]
+        #if os(watchOS)
+        // watchOS 26 and later provide an interface for configuring widgets and
+        // complications, so return an empty array to let people configure them.
+        if #available(watchOS 26.0, *) {
+            return []
+        }
+        #endif
+        return [AppIntentRecommendation(intent: ReadingWidgetConfiguration(), description: "Current Reading")]
     }
 
     private func makeState(for configuration: ReadingWidgetConfiguration) async -> Entry.State {


### PR DESCRIPTION
Return an empty recommendations array on watchOS 26+ so the system lets
people configure the reading and graph complications/widgets themselves.
Older watchOS versions lack a configuration interface, so they continue
to receive preconfigured recommendations.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W564XoSVJSVfpg3hhV7ZH4