### PR TITLE
Add experimental auto-restart Live Activity toggle

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -57,6 +57,9 @@ final class LiveActivityManager {
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)
                     syncState()
+                    if state == .ended, Defaults[.autoRestartLiveActivity] {
+                        await restartLiveActivity()
+                    }
                     return
                 case .active, .pending, .stale:
                     break
@@ -115,6 +118,15 @@ final class LiveActivityManager {
             } catch {
                 TelemetryDeck.signal("LiveActivity.failedToSendToken", parameters: ["kind": kind])
             }
+        }
+    }
+
+    private func restartLiveActivity() async {
+        do {
+            _ = try await StartLiveActivityIntent(source: "auto-restart").perform()
+            TelemetryDeck.signal("LiveActivity.autoRestarted")
+        } catch {
+            TelemetryDeck.signal("LiveActivity.failedToAutoRestart")
         }
     }
 

--- a/Luka/Views/ExperimentalView.swift
+++ b/Luka/Views/ExperimentalView.swift
@@ -12,6 +12,7 @@ import ActivityKit
 struct ExperimentalView: View {
     @Default(.debugInfo) private var debugInfo
     @Default(.useReadingsProxy) private var useReadingsProxy
+    @Default(.autoRestartLiveActivity) private var autoRestartLiveActivity
 
     @State private var showCompleteAlert = false
 
@@ -65,6 +66,15 @@ struct ExperimentalView: View {
                     .tint(.accent)
             } footer: {
                 Text("Fetch glucose readings from the Luka server when a Live Activity is running. Falls back to Dexcom if no cached readings are available.")
+            }
+
+            Section {
+                Toggle("Automatically restart Live Activity", isOn: $autoRestartLiveActivity)
+                    .tint(.accent)
+            } header: {
+                Text("Experimental")
+            } footer: {
+                Text("Start a new Live Activity automatically when the current one ends from the server.")
             }
         }
         .listStyle(.insetGrouped)

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -40,6 +40,7 @@ extension Defaults.Keys {
     static let cachedReadings = Key<GlucoseReadingsCache?>("cachedReadings", default: nil, suite: .shared)
     static let useReadingsProxy = Key<Bool>("useReadingsProxy", default: true, suite: .shared, iCloud: true)
     static let debugInfo = Key<Bool>("debugInfo", default: false, suite: .shared)
+    static let autoRestartLiveActivity = Key<Bool>("autoRestartLiveActivity", default: false, suite: .shared, iCloud: true)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
Add an "Automatically restart Live Activity" toggle under an Experimental
header in the advanced view. When enabled, the app starts a new Live
Activity whenever the current one is ended by the server.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jv9zjNZnuL99sw1CU5WAjt