### PR TITLE
Send push-to-start token for Live Activity auto-restart

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -23,6 +23,12 @@ final class LiveActivityManager {
     private var observationTasks: [String: Task<Void, Never>] = [:]
     private var activityTokens: [String: String] = [:]
     private var activityUpdatesTask: Task<Void, Never>?
+    private var pushToStartTask: Task<Void, Never>?
+
+    /// Latest push-to-start token for this device. Sent to the server (when the
+    /// auto-restart experiment is enabled) so it can restart the Live Activity
+    /// after the time limit is reached.
+    private var pushToStartToken: String?
 
     private init() {
         // Observe existing activities
@@ -37,6 +43,17 @@ final class LiveActivityManager {
             for await activity in Activity<ReadingAttributes>.activityUpdates {
                 observeActivity(activity)
                 syncState()
+            }
+        }
+
+        // Observe the device's push-to-start token. This arrives even when no
+        // activity is running; re-register any running activity so the server
+        // picks up the token (covers the first-launch race where the update
+        // token is sent before the push-to-start token exists).
+        pushToStartTask = Task {
+            for await data in Activity<ReadingAttributes>.pushToStartTokenUpdates {
+                pushToStartToken = data.map { String(format: "%02x", $0) }.joined()
+                await reregisterRunningActivities()
             }
         }
     }
@@ -57,9 +74,6 @@ final class LiveActivityManager {
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)
                     syncState()
-                    if state == .ended, Defaults[.autoRestartLiveActivity] {
-                        await restartLiveActivity()
-                    }
                     return
                 case .active, .pending, .stale:
                     break
@@ -95,6 +109,10 @@ final class LiveActivityManager {
         }
 
         let range: GraphRange = .threeHours
+
+        // Gate auto-restart behind the experimental toggle: only hand the server
+        // a push-to-start token (and the attributes to replay) when enabled.
+        let restartEnabled = Defaults[.autoRestartLiveActivity]
         let payload = StartLiveActivityRequest(
             activityID: activityID,
             pushToken: token,
@@ -107,7 +125,10 @@ final class LiveActivityManager {
                 targetRange: Int(Defaults[.targetRangeLowerBound])...Int(Defaults[.targetRangeUpperBound]),
                 unit: Defaults[.unit],
                 alertsEnabled: Defaults[.liveActivityAlertsEnabled]
-            )
+            ),
+            pushToStartToken: restartEnabled ? pushToStartToken : nil,
+            attributesType: restartEnabled ? "ReadingAttributes" : nil,
+            attributes: restartEnabled ? try? JSONValue(encoding: ReadingAttributes(range: range)) : nil
         )
 
         await client.withBackgroundTask(name: "LiveActivity.sendStartLiveActivity") {
@@ -121,12 +142,21 @@ final class LiveActivityManager {
         }
     }
 
-    private func restartLiveActivity() async {
-        do {
-            _ = try await StartLiveActivityIntent(source: "auto-restart").perform()
-            TelemetryDeck.signal("LiveActivity.autoRestarted")
-        } catch {
-            TelemetryDeck.signal("LiveActivity.failedToAutoRestart")
+    /// Re-sends the start registration for every running activity using its
+    /// most recent push token, so the server receives the latest push-to-start
+    /// token. Called when the push-to-start token updates.
+    private func reregisterRunningActivities() async {
+        for activity in Activity<ReadingAttributes>.activities {
+            switch activity.activityState {
+            case .active, .pending, .stale:
+                if let token = activityTokens[activity.id] {
+                    await sendStartLiveActivity(activityID: activity.id, token: token, kind: "update")
+                }
+            case .dismissed, .ended:
+                break
+            @unknown default:
+                break
+            }
         }
     }
 

--- a/Shared/Models/StartLiveActivityRequest.swift
+++ b/Shared/Models/StartLiveActivityRequest.swift
@@ -37,4 +37,70 @@ struct StartLiveActivityRequest: Codable {
     var accountLocation: AccountLocation
     var duration: TimeInterval
     var preferences: LiveActivityPreferences?
+
+    /// Push-to-start token for this device, so the server can auto-restart the
+    /// Live Activity when it ends because the time limit was reached.
+    var pushToStartToken: String?
+    /// The ActivityAttributes type name, replayed by the server in the start push.
+    var attributesType: String?
+    /// The activity's static attributes, replayed by the server in the start push.
+    /// Stored as opaque JSON so this shared model stays decoupled from `ReadingAttributes`
+    /// (which isn't a member of every target that compiles this file, e.g. the Watch).
+    var attributes: JSONValue?
+}
+
+/// A minimal, Foundation-only recursive JSON value. Lets the request carry the activity's
+/// attributes opaquely without depending on the `ReadingAttributes` type, mirroring the
+/// server. Encode any `Encodable` into one via `init(encoding:)`.
+enum JSONValue: Codable, Sendable, Hashable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    /// Builds a `JSONValue` by round-tripping any `Encodable` through JSON.
+    init(encoding value: some Encodable) throws {
+        let data = try JSONEncoder().encode(value)
+        self = try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
 }


### PR DESCRIPTION
## What

Make the `autoRestartLiveActivity` experiment actually work by feeding the server a push-to-start token, so it can restart the Live Activity on this device when it hits its time limit.

The previous implementation fired `StartLiveActivityIntent` from `activityStateUpdates == .ended`, which can't run when the activity ends in the background — so it did nothing. This replaces it with the push-to-start path (server restarts via APNs; see luka-vapor companion PR).

## Changes

- Observe `Activity<ReadingAttributes>.pushToStartTokenUpdates`; store the latest token and re-register running activities when it arrives (covers the first-launch race where the update token is sent before the PtS token exists).
- When the experiment is enabled, include `pushToStartToken`, `attributesType` ("ReadingAttributes"), and `attributes` in `start-live-activity`. All three are gated together behind the toggle.
- Carry `attributes` as a Foundation-only `JSONValue` (encoded from `ReadingAttributes`) so the shared request model stays decoupled from `ReadingAttributes`, which isn't a member of the Watch target.
- Remove the old broken `restartLiveActivity()` path.

## Notes

Gated behind `autoRestartLiveActivity` (default off). Additive request fields; the server ignores them if unsupported, so this is safe to ship independently. The new activity created by the server's push-to-start is picked up by the existing `Activity.activityUpdates` observer, which re-registers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
