### PR TITLE
Debug restart button + push-to-start indicator

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -160,6 +160,29 @@ final class LiveActivityManager {
         }
     }
 
+    /// Debug-only: asks the server to manually trigger a push-to-start restart for each
+    /// running activity, for testing without waiting for the time limit. Requires the
+    /// auto-restart experiment to have been enabled (so the server has a push-to-start token).
+    func debugRestartLiveActivityOnServer() async {
+        guard let username = Keychain.shared.username else { return }
+        for activity in Activity<ReadingAttributes>.activities {
+            let payload = DebugRestartLiveActivityRequest(
+                username: username,
+                activityID: activity.id,
+                pushToken: activityTokens[activity.id]
+            )
+            await client.withBackgroundTask(name: "LiveActivity.debugRestart") {
+                do {
+                    let request = try client.makePostRequest("restart-live-activity", body: payload)
+                    try await client.send(request)
+                    TelemetryDeck.signal("LiveActivity.sentDebugRestart")
+                } catch {
+                    TelemetryDeck.signal("LiveActivity.failedToSendDebugRestart")
+                }
+            }
+        }
+    }
+
     func endLiveActivityOnServer() async {
         for activity in Activity<ReadingAttributes>.activities {
             await sendEndLiveActivity(activityID: activity.id)

--- a/Luka/Views/ExperimentalView.swift
+++ b/Luka/Views/ExperimentalView.swift
@@ -59,6 +59,16 @@ struct ExperimentalView: View {
                     SettingsRow("End all Live Activities", systemImage: "xmark.circle")
                 }
                 .fontWeight(.medium)
+
+                Button {
+                    Task {
+                        await LiveActivityManager.shared.debugRestartLiveActivityOnServer()
+                        showCompleteAlert = true
+                    }
+                } label: {
+                    SettingsRow("Restart via push-to-start", systemImage: "arrow.clockwise.circle")
+                }
+                .fontWeight(.medium)
             }
 
             Section {

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -501,6 +501,7 @@ private struct DebugInfoList: View {
             DebugRow(label: "Push date", value: context.state.pd?.formatted())
             DebugRow(label: "Local date", value: Date.now.formatted())
             DebugRow(label: "Tokens", value: context.state.tc.map { "\($0)" })
+            DebugRow(label: "Push-to-start", value: context.state.ps.map { $0 ? "Available" : "None" })
         }
         .font(.subheadline.bold())
     }

--- a/Shared/Models/EndLiveActivityRequest.swift
+++ b/Shared/Models/EndLiveActivityRequest.swift
@@ -17,3 +17,10 @@ struct EndLiveActivityRequest: Codable {
 struct EndLiveActivitiesRequest: Codable {
     var username: String
 }
+
+/// Debug-only: asks the server to manually trigger a push-to-start restart for one activity.
+struct DebugRestartLiveActivityRequest: Codable {
+    var username: String
+    var activityID: String?
+    var pushToken: String?
+}

--- a/Shared/Models/LiveActivityState.swift
+++ b/Shared/Models/LiveActivityState.swift
@@ -41,6 +41,9 @@ struct LiveActivityState: Codable, Hashable {
     var pd: Date?
     /// reason — short human-readable reason for non-reading pushes
     var r: String?
+    /// pushToStartAvailable — whether the server has a push-to-start token for this session
+    /// (i.e. it's eligible for auto-restart). Shown in debug info.
+    var ps: Bool?
 
     /// Creates a LiveActivityState from readings, filtering history to the specified range
     init(readings: [GlucoseReading], range: GraphRange) {
@@ -62,7 +65,8 @@ struct LiveActivityState: Codable, Hashable {
         td: Date? = nil,
         tc: Int? = nil,
         pd: Date? = nil,
-        r: String? = nil
+        r: String? = nil,
+        ps: Bool? = nil
     ) {
         self.c = c
         self.h = h
@@ -73,5 +77,6 @@ struct LiveActivityState: Codable, Hashable {
         self.tc = tc
         self.pd = pd
         self.r = r
+        self.ps = ps
     }
 }


### PR DESCRIPTION
## What

Testing aids for push-to-start auto-restart (pairs with luka-vapor #51).

- **Debug button:** Advanced → Live Activities → "Restart via push-to-start" calls the new `restart-live-activity` endpoint for each running activity, so you can trigger a restart without waiting for the 7h limit. Requires the auto-restart experiment to have been enabled (so the server has a push-to-start token).
- **Indicator:** the Live Activity debug info ("Show debug info") gains a "Push-to-start" row (Available/None), driven by the new `LiveActivityState.ps` the server sets on each push — so you can confirm a session is eligible for auto-restart.

Additive optional `ps` field; backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
