### PR TITLE
Depend on activityID instead of push token for Live Activities

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -168,8 +168,7 @@ final class LiveActivityManager {
         for activity in Activity<ReadingAttributes>.activities {
             let payload = DebugRestartLiveActivityRequest(
                 username: username,
-                activityID: activity.id,
-                pushToken: activityTokens[activity.id]
+                activityID: activity.id
             )
             await client.withBackgroundTask(name: "LiveActivity.debugRestart") {
                 do {
@@ -206,10 +205,11 @@ final class LiveActivityManager {
     }
 
     private func sendEndLiveActivity(activityID: String) async {
-        guard let username = Keychain.shared.username,
-              let pushToken = activityTokens[activityID] else { return }
+        guard let username = Keychain.shared.username else { return }
 
-        let payload = EndLiveActivityRequest(pushToken: pushToken, username: username, activityID: activityID)
+        // Match is by activityID, so end regardless of whether a push token was captured
+        // locally — the server no-ops if it has no entry for this activity.
+        let payload = EndLiveActivityRequest(username: username, activityID: activityID)
 
         await client.withBackgroundTask(name: "LiveActivity.sendEndLiveActivity") {
             do {

--- a/Luka/Views/LiveActivityDebugView.swift
+++ b/Luka/Views/LiveActivityDebugView.swift
@@ -118,6 +118,7 @@ struct LiveActivityDebugView: View {
             LabeledContent("Token count", value: state.tc.map { "\($0)" } ?? "nil")
             LabeledContent("Push date", value: dateOrNil(state.pd))
             LabeledContent("Reason", value: state.r ?? "nil")
+            LabeledContent("Push-to-start", value: state.ps.map { $0 ? "Available" : "None" } ?? "nil")
         }
     }
 

--- a/Shared/Models/EndLiveActivityRequest.swift
+++ b/Shared/Models/EndLiveActivityRequest.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 struct EndLiveActivityRequest: Codable {
-    var pushToken: String
     var username: String
-    var activityID: String?
+    /// Stable per-activity identity (ActivityKit's `Activity.id`); the server's sole match key.
+    var activityID: String
 }
 
 struct EndLiveActivitiesRequest: Codable {
@@ -21,6 +21,6 @@ struct EndLiveActivitiesRequest: Codable {
 /// Debug-only: asks the server to manually trigger a push-to-start restart for one activity.
 struct DebugRestartLiveActivityRequest: Codable {
     var username: String
-    var activityID: String?
-    var pushToken: String?
+    /// Stable per-activity identity (ActivityKit's `Activity.id`); the server's sole match key.
+    var activityID: String
 }

--- a/Shared/Models/StartLiveActivityRequest.swift
+++ b/Shared/Models/StartLiveActivityRequest.swift
@@ -29,7 +29,9 @@ struct LiveActivityPreferences: Codable {
 }
 
 struct StartLiveActivityRequest: Codable {
-    var activityID: String?
+    /// Stable per-activity identity (ActivityKit's `Activity.id`). Always sent so the
+    /// server can map a rotated push token back to the same activity.
+    var activityID: String
     var pushToken: String
     var environment: PushEnvironment
     var username: String?


### PR DESCRIPTION
## What

Mirrors the luka-vapor change: `activityID` (ActivityKit's `Activity.id`) is now the sole key the server uses to match a Live Activity.

- Make `activityID` **required** on `StartLiveActivityRequest`, `EndLiveActivityRequest`, and `DebugRestartLiveActivityRequest` (it was always populated from `activity.id`).
- Stop sending `pushToken` on end/restart requests; the server no longer reads it. End now fires purely by `activityID`, so drop the captured-token guard in `sendEndLiveActivity` (the server no-ops on an unknown id).
- Show push-to-start availability in the Live Activity debug view.

Pairs with the matching luka-vapor PR.

## Testing

- `Luka` and `Watch` schemes build clean.
- Adversarial review traced all `sendEndLiveActivity` callers (state observer, debug button, start intent, push-to-start auto-restart) — no premature/spurious/cross-activity ends. Verdict: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)