### PR TITLE
Use caption2 font for Live Activity debug info

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -518,7 +518,7 @@ private struct DebugInfoList: View {
                 DebugCell(label: "Push-to-start", value: context.state.ps.map { $0 ? "Available" : "None" })
             }
         }
-        .font(.subheadline.bold())
+        .font(.caption2.bold())
     }
 }
 


### PR DESCRIPTION
Shrinks the Live Activity debug info text from `subheadline.bold()` to `caption2.bold()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFpu5JJvu7s7bcpggRwMKW