### PR TITLE
Persist push-to-start token so token rotations don't disarm restart

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -25,11 +25,6 @@ final class LiveActivityManager {
     private var activityUpdatesTask: Task<Void, Never>?
     private var pushToStartTask: Task<Void, Never>?
 
-    /// Latest push-to-start token for this device. Sent to the server (when the
-    /// auto-restart experiment is enabled) so it can restart the Live Activity
-    /// after the time limit is reached.
-    private var pushToStartToken: String?
-
     private init() {
         // Observe existing activities
         for activity in Activity<ReadingAttributes>.activities {
@@ -46,13 +41,23 @@ final class LiveActivityManager {
             }
         }
 
-        // Observe the device's push-to-start token. This arrives even when no
-        // activity is running; re-register any running activity so the server
-        // picks up the token (covers the first-launch race where the update
-        // token is sent before the push-to-start token exists).
+        // Observe the device's push-to-start token and persist it. Persisting (rather
+        // than holding it only in memory) means a push-token rotation that
+        // background-relaunches the app still carries the token on re-registration —
+        // otherwise the fresh process sends nil before this stream re-yields, which
+        // clears the token server-side and breaks the hour-7 auto-restart.
+        //
+        // The token arrives even when no activity is running. Only act on a real
+        // change: the stream re-yields the same token on most cold launches, and
+        // re-registering then is wasted work — routine rotations already carry the
+        // persisted token. On a genuine change (or first acquisition while an activity
+        // is already running) we re-register so the server learns the new token now
+        // instead of waiting for the next rotation.
         pushToStartTask = Task {
             for await data in Activity<ReadingAttributes>.pushToStartTokenUpdates {
-                pushToStartToken = data.map { String(format: "%02x", $0) }.joined()
+                let token = data.map { String(format: "%02x", $0) }.joined()
+                guard token != Defaults[.pushToStartToken] else { continue }
+                Defaults[.pushToStartToken] = token
                 await reregisterRunningActivities()
             }
         }
@@ -126,7 +131,7 @@ final class LiveActivityManager {
                 unit: Defaults[.unit],
                 alertsEnabled: Defaults[.liveActivityAlertsEnabled]
             ),
-            pushToStartToken: restartEnabled ? pushToStartToken : nil,
+            pushToStartToken: restartEnabled ? Defaults[.pushToStartToken] : nil,
             attributesType: restartEnabled ? "ReadingAttributes" : nil,
             attributes: restartEnabled ? try? JSONValue(encoding: ReadingAttributes(range: range)) : nil
         )

--- a/Shared/Utilities/Defaults.swift
+++ b/Shared/Utilities/Defaults.swift
@@ -41,6 +41,10 @@ extension Defaults.Keys {
     static let useReadingsProxy = Key<Bool>("useReadingsProxy", default: true, suite: .shared, iCloud: true)
     static let debugInfo = Key<Bool>("debugInfo", default: false, suite: .shared)
     static let autoRestartLiveActivity = Key<Bool>("autoRestartLiveActivity", default: false, suite: .shared, iCloud: true)
+    // Device-local (not iCloud-synced): the push-to-start token is per-install and must
+    // not leak to another device. Persisted so a token rotation that background-relaunches
+    // the app can still hand it to the server before the PTS stream re-yields.
+    static let pushToStartToken = Key<String?>("pushToStartToken", default: nil, suite: .shared)
 }
 
 extension AccountLocation: Defaults.Serializable {}


### PR DESCRIPTION
## Problem

The push-to-start token was held **only in memory** (`LiveActivityManager.pushToStartToken`). When iOS rotates an activity's push token it often background-relaunches the app; on that fresh process the activity re-registers (`pushTokenUpdates` → `sendStartLiveActivity`) **before** the `pushToStartTokenUpdates` stream re-yields, so it sends `pushToStartToken: nil`.

The server stores that value verbatim (`nil` clears the stored token, by design, as the opt-out path), so the rotation silently wipes the token and the hour-7 auto-restart can't fire.

Observed in production last night: a rotated token (`40fcc84b`) re-registered twice with no token, then ended with `max_duration` instead of `max_duration_restarted`, leaving no Live Activity until the app was reopened.

## Fix

- Persist the push-to-start token to **shared, device-local** `Defaults` (not iCloud-synced — it's per-install and must not leak across devices).
- Read it from `Defaults` at registration, so every token rotation carries the last-known token even before the stream re-yields on a fresh process.
- Gate the observer on an actual change so routine cold-launch re-yields of the same token don't trigger redundant re-registrations. `reregisterRunningActivities()` still fires on a genuine change / first acquisition so the server learns it promptly.

`restartEnabled ? … : nil` is preserved, so toggling the experiment off still clears the token server-side — opt-out intact, no server/protocol changes.

## Notes

- No server changes required.
- Follow-up to watch after ship: last night's actual restart fired but produced no re-registration — worth confirming the app reliably wakes to observe the push-to-started activity in the background so restarts chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)