### PR TITLE
Render out-of-range readings with lowercase small caps

### DIFF
--- a/Luka.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Luka.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/kylebshr/dexcom-swift",
       "state" : {
         "branch" : "main",
-        "revision" : "370a0b69fc59d3c705c60e5302f43aee1b87041d"
+        "revision" : "732e832bbf11961e744d5f97d24c94218ab85734"
       }
     },
     {

--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -93,6 +93,7 @@ private struct ReadingText: View {
                     .redacted(reason: .placeholder)
             }
         }
+        .lowercaseSmallCaps()
     }
 }
 

--- a/Shared/Utilities/View+Extensions.swift
+++ b/Shared/Utilities/View+Extensions.swift
@@ -15,4 +15,20 @@ extension View {
         return false
         #endif
     }
+
+    /// Applies lowercase small caps to the current font. Glucose readings
+    /// outside the sensor's measurable range format as "Low"/"Hi", and small
+    /// caps renders those words at a height that sits well alongside the
+    /// numeric readings.
+    func lowercaseSmallCaps() -> some View {
+        modifier(LowercaseSmallCapsModifier())
+    }
+}
+
+private struct LowercaseSmallCapsModifier: ViewModifier {
+    @Environment(\.font) private var font
+
+    func body(content: Content) -> some View {
+        content.font((font ?? .body).lowercaseSmallCaps())
+    }
 }

--- a/Shared/Views/ReadingView.swift
+++ b/Shared/Views/ReadingView.swift
@@ -38,6 +38,7 @@ struct ReadingView: View {
                     .transition(.blurReplace)
             }
         }
+        .lowercaseSmallCaps()
         .redacted(reason: reading == nil ? .placeholder : [])
         .imageScale(.small)
     }

--- a/Shared/Widgets/Views/CircularWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CircularWidgetReadingView.swift
@@ -41,6 +41,7 @@ struct CircularWidgetView : View {
             currentValueLabel: {
                 VStack(spacing: watchOS ? -4 : -2) {
                     Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
+                        .lowercaseSmallCaps()
                         .minimumScaleFactor(0.5)
                         .fontWeight(.bold)
                         .invalidatableContent()

--- a/Shared/Widgets/Views/CornerWidgetReadingView.swift
+++ b/Shared/Widgets/Views/CornerWidgetReadingView.swift
@@ -36,6 +36,7 @@ struct CornerWidgetView: View {
 
     private var content: some View {
         Text(redactionReasons.isEmpty ? reading.value.formatted(.glucose(unit)) : "80")
+            .lowercaseSmallCaps()
             .invalidatableContent()
             .foregroundStyle(reading.color(target: targetLower...targetUpper))
             .widgetCurvesContent()

--- a/Shared/Widgets/Views/InlineWidgetReadingView.swift
+++ b/Shared/Widgets/Views/InlineWidgetReadingView.swift
@@ -30,6 +30,7 @@ struct InlineWidgetReadingView: View {
             )
 
             Text("\(reading.value.formatted(.glucose(unit))) \(timestamp)")
+                .lowercaseSmallCaps()
         }
         .containerBackground(.background, for: .widget)
     }


### PR DESCRIPTION
dexcom-swift's formatter now returns "Low"/"Hi" for readings outside the
sensor's measurable range (40–400 mg/dL). Bump the dependency to pick that
up and apply a `.lowercaseSmallCaps()` modifier everywhere a reading is
shown so those words sit at a height that matches the numeric readings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wuf8qsrxL9gwZLMUA5wCy2