### PR TITLE
Hold background assertion across Live Activity end teardown

### DIFF
--- a/Luka/LiveActivityManager.swift
+++ b/Luka/LiveActivityManager.swift
@@ -75,13 +75,22 @@ final class LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .dismissed, .ended:
-                    await sendEndLiveActivity(activityID: activity.id)
                     observationTasks.removeValue(forKey: activity.id)
                     activityTokens.removeValue(forKey: activity.id)
-                    // Exclude this activity: it just ended, but Activity.activities can still
-                    // report it as running for a moment, which would leave the flag (and the
-                    // Control Center toggle) stuck "on" until the next foreground sync.
-                    syncState(excluding: activity.id)
+                    // Dismissal happens while the app is backgrounded (you're on the Lock
+                    // Screen), so the app is suspended moments later. Hold a background
+                    // assertion across the *entire* teardown — not just the network call —
+                    // so the shared-default write actually reaches the App Group store and
+                    // the control reload isn't dropped before suspension. Otherwise the
+                    // Control Center toggle's currentValue() keeps reading the stale
+                    // "running" value even after Control Center is reopened.
+                    //
+                    // Exclude this activity from the running check: Activity.activities can
+                    // still report it as running for a moment after this state update fires.
+                    await client.withBackgroundTask(name: "LiveActivity.handleEnd") {
+                        syncState(excluding: activity.id)
+                        await sendEndLiveActivity(activityID: activity.id)
+                    }
                     return
                 case .active, .pending, .stale:
                     break


### PR DESCRIPTION
## Problem

When you dismiss a Live Activity from the Lock Screen, the server correctly receives the end event, but the **Control Center toggle stays stuck "on"** — even after closing and reopening Control Center. (The in-app button recovers, because it heals on the next app foreground.)

## Root cause

Dismissal happens while the app is backgrounded, so it's suspended moments later. The end handler wrote the shared `isLiveActivityRunning` default and reloaded the control **after** the network call's background-task assertion had already been released:

```swift
await sendEndLiveActivity(...)   // assertion held here, then RELEASED
syncState(excluding: activity.id)   // write + reload run with no assertion → racing suspension
```

So the `Defaults[.isLiveActivityRunning] = false` write often never propagated to the App Group store (cfprefsd) before the app suspended. The control extension's `currentValue()` — which is re-evaluated every time Control Center opens — then kept reading the stale `true`.

Verified the value (not the reload) was stale: reopening Control Center re-runs `currentValue()` and it *still* read `true`, which only happens if the write never made it out of the app.

## Fix

Wrap the entire teardown — default write, control reload, and the end POST — in a single background-task assertion, so the shared write propagates and the reload isn't dropped before suspension:

```swift
await client.withBackgroundTask(name: "LiveActivity.handleEnd") {
    syncState(excluding: activity.id)
    await sendEndLiveActivity(activityID: activity.id)
}
```

## Testing

- `xcodebuild -scheme Luka` builds clean.
- Needs on-device verification (suspension timing doesn't reproduce in the simulator): dismiss from the Lock Screen, then reopen Control Center without launching the app — the toggle should now read off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxuuAN5RHEdKFt3bZaYYkN