### PR TITLE
Fix small content view background color for boundary readings

### DIFF
--- a/LukaWidget/ReadingActivityConfiguration.swift
+++ b/LukaWidget/ReadingActivityConfiguration.swift
@@ -606,10 +606,17 @@ private extension GlucoseReading {
     /// low/inRange/high colors mix in pink/mint/orange which wash out at low
     /// opacity over a dark background.
     func vividColor(target: ClosedRange<Double>) -> Color {
-        switch Double(value) {
-        case ..<target.lowerBound: .red
-        case ...target.upperBound: .green
-        default: .yellow
+        // Compare against integer-truncated bounds to stay consistent with the
+        // chart's `colorForValue`. The target bounds are stored as Doubles and a
+        // slider-set "70" can land just above 70 (e.g. 70.0000001), which would
+        // otherwise mark an in-range reading as low (red) here while the chart
+        // shows it in range (green).
+        if value < Int(target.lowerBound) {
+            return .red
+        } else if value > Int(target.upperBound) {
+            return .yellow
+        } else {
+            return .green
         }
     }
 }

--- a/Shared/Utilities/GlucoseReading+Extensions.swift
+++ b/Shared/Utilities/GlucoseReading+Extensions.swift
@@ -10,10 +10,17 @@ import SwiftUI
 
 extension GlucoseReading {
     func color(target: ClosedRange<Double>) -> Color {
-        switch Double(value) {
-        case ..<target.lowerBound: .lowColor
-        case ...target.upperBound: .inRangeColor
-        default: .highColor
+        // Compare against integer-truncated bounds to stay consistent with the
+        // chart's `colorForValue`. The target bounds are stored as Doubles and a
+        // slider-set "70" can land just above 70 (e.g. 70.0000001), which would
+        // otherwise mark an in-range reading as low while the chart shows it in
+        // range.
+        if value < Int(target.lowerBound) {
+            return .lowColor
+        } else if value > Int(target.upperBound) {
+            return .highColor
+        } else {
+            return .inRangeColor
         }
     }
 


### PR DESCRIPTION
The Live Activity small content view background (vividColor) and the
shared color(target:) classifier compared the glucose value against the
raw Double target bounds, while the chart's colorForValue truncates the
bounds with Int(). Because the target-range sliders store Doubles, a
slider-set bound can land just above an integer (e.g. 70.0000001), so a
reading of 70 was classified as low (red background) even though the
chart correctly showed it in range (green).

Make both classifiers compare against integer-truncated bounds so the
background, keyline tint, and chart all agree at the range boundary.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VPJstUNBp1S88XGUj1d1yp